### PR TITLE
Allow ViewOptF in InputEV

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 

--- a/src/main/scala/gpp/ui/forms/ExternalValue.scala
+++ b/src/main/scala/gpp/ui/forms/ExternalValue.scala
@@ -4,28 +4,38 @@
 package lucuma.ui.forms
 
 import cats.effect.Effect
+import cats.implicits._
 import crystal.ViewF
+import crystal.ViewOptF
 import crystal.react.implicits._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.StateSnapshot
 
 trait ExternalValue[EV[_]] {
-  def get[A](ev: EV[A]): A
+  def get[A](ev: EV[A]): Option[A]
   def set[A](ev: EV[A]): A => Callback
 }
 
 object ExternalValue {
   implicit def externalValueViewF[F[_]: Effect]: ExternalValue[ViewF[F, *]] =
     new ExternalValue[ViewF[F, *]] {
-      override def get[A](ev: ViewF[F, A]): A = ev.get
+      override def get[A](ev: ViewF[F, A]): Option[A] = ev.get.some
 
       override def set[A](ev: ViewF[F, A]): A => Callback =
         ev.set.andThen(_.runInCB)
     }
 
+  implicit def externalValueViewOptF[F[_]: Effect]: ExternalValue[ViewOptF[F, *]] =
+    new ExternalValue[ViewOptF[F, *]] {
+      override def get[A](ev: ViewOptF[F, A]): Option[A] = ev.get
+
+      override def set[A](ev: ViewOptF[F, A]): A => Callback =
+        ev.set.andThen(_.runInCB)
+    }
+
   implicit val externalValueStateSnapshot: ExternalValue[StateSnapshot] =
     new ExternalValue[StateSnapshot] {
-      override def get[A](ev: StateSnapshot[A]): A = ev.value
+      override def get[A](ev: StateSnapshot[A]): Option[A] = ev.value.some
 
       override def set[A](ev: StateSnapshot[A]): A => Callback = ev.setState
     }

--- a/src/main/scala/gpp/ui/forms/FormInputEV.scala
+++ b/src/main/scala/gpp/ui/forms/FormInputEV.scala
@@ -60,7 +60,7 @@ final case class FormInputEV[EV[_], A](
   onBlur:          FormInputEV.ChangeCallback[A] = (_: A) => Callback.empty
 )(implicit val ev: ExternalValue[EV])
     extends ReactProps[FormInputEV[Any, Any]](FormInputEV.component) {
-  def valGet: String = format.reverseGet(ev.get(value))
+  def valGet: String = ev.get(value).foldMap(format.reverseGet)
   def valSet(s: String): Callback =
     format.getOption(s).map(ev.set(value)).getOrEmpty
   val onBlurC: InputEV.ChangeCallback[String]   =

--- a/src/main/scala/gpp/ui/forms/InputEV.scala
+++ b/src/main/scala/gpp/ui/forms/InputEV.scala
@@ -29,7 +29,7 @@ final case class InputEV[EV[_], A](
   onBlur:          InputEV.ChangeCallback[A] = (_: A) => Callback.empty
 )(implicit val ev: ExternalValue[EV])
     extends ReactProps[InputEV[Any, Any]](InputEV.component) {
-  def valGet: String = format.reverseGet(ev.get(value))
+  def valGet: String = ev.get(value).foldMap(format.reverseGet)
   def valSet(s: String): Callback = format.getOption(s).map(ev.set(value)).getOrEmpty
   val onBlurC: InputEV.ChangeCallback[String]   =
     (s: String) => format.getOption(s).map(onBlur).getOrEmpty

--- a/src/main/scala/gpp/ui/reusability/package.scala
+++ b/src/main/scala/gpp/ui/reusability/package.scala
@@ -4,10 +4,11 @@
 package lucuma.ui
 
 import eu.timepit.refined.api.RefType
-import lucuma.core.model._
+import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
 import lucuma.core.data.EnumZipper
-import lucuma.core.math.Angle
+import lucuma.core.math._
+import lucuma.core.model._
 import lucuma.core.util.Enumerated
 
 /**
@@ -25,8 +26,15 @@ trait UtilReusabilityInstances {
  * Instances of reusability for some common math types
  */
 trait MathReusabilityInstances {
-  implicit val angleReuse: Reusability[Angle] =
+  implicit val angleReuse: Reusability[Angle]             =
     Reusability.by(_.toMicroarcseconds)
+  implicit def raReuse: Reusability[RightAscension]       = Reusability.byEq
+  implicit def decReuse: Reusability[Declination]         = Reusability.byEq
+  implicit def coordinatesReuse: Reusability[Coordinates] = Reusability.byEq
+  implicit def epochReuse: Reusability[Epoch]             = Reusability.byEq
+  implicit def pvReuse: Reusability[ProperVelocity]       = Reusability.byEq
+  implicit def rvReuse: Reusability[RadialVelocity]       = Reusability.byEq
+  implicit def parallaxReuse: Reusability[Parallax]       = Reusability.byEq
 }
 
 /**
@@ -42,14 +50,19 @@ trait RefinedReusabiltyInstances {
 /**
  * Reusability instances for model classes
  */
-trait ModelReusabiltyInstances extends RefinedReusabiltyInstances {
-  implicit val userIdReuse: Reusability[User.Id]                 = Reusability.derive
-  implicit val orcidIdReuse: Reusability[OrcidId]                = Reusability.by(_.value.toString)
-  implicit val orcidProfileResuse: Reusability[OrcidProfile]     = Reusability.derive
-  implicit val standardRoleIdReuse: Reusability[StandardRole.Id] = Reusability.derive
-  implicit val partnerReuse: Reusability[Partner]                = Reusability.derive
-  implicit val standardRoleReuse: Reusability[StandardRole]      = Reusability.derive
-  implicit val standardUserReuse: Reusability[StandardUser]      = Reusability.derive
+trait ModelReusabiltyInstances
+    extends RefinedReusabiltyInstances
+    with UtilReusabilityInstances
+    with MathReusabilityInstances {
+  implicit val userIdReuse: Reusability[User.Id]                    = Reusability.derive
+  implicit val orcidIdReuse: Reusability[OrcidId]                   = Reusability.by(_.value.toString)
+  implicit val orcidProfileResuse: Reusability[OrcidProfile]        = Reusability.derive
+  implicit val standardRoleIdReuse: Reusability[StandardRole.Id]    = Reusability.derive
+  implicit val partnerReuse: Reusability[Partner]                   = Reusability.derive
+  implicit val standardRoleReuse: Reusability[StandardRole]         = Reusability.derive
+  implicit val standardUserReuse: Reusability[StandardUser]         = Reusability.derive
+  implicit def catalogIdReuse: Reusability[CatalogId]               = Reusability.derive
+  implicit def siderealTrackingReuse: Reusability[SiderealTracking] = Reusability.derive
 }
 
 package object reusability


### PR DESCRIPTION
This PR adds the capability of making `InputEV` components that take an optional value
Added also some extra reusable instances and reverted the scalajs upgrade