### PR TITLE
Add EnumViewOptionalSelect

### DIFF
--- a/src/main/scala/gpp/ui/forms/EnumViewMultipleSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewMultipleSelect.scala
@@ -107,14 +107,15 @@ final case class EnumViewMultipleSelect[F[_], A](
     with EnumViewSelectBase {
 
   type AA    = A
-  type BB    = Set[A]
+  type GG[X] = Set[X]
   type FF[X] = F[X]
 
-  val clearable = false
-  val multiple  = true
+  override val clearable = false
+  override val multiple  = true
 
   def withMods(mods: TagMod*): EnumViewMultipleSelect[F, A] = copy(modifiers = modifiers ++ mods)
-  def setter(ddp: FormDropdown.FormDropdownProps): Callback = {
+
+  override def setter(ddp: FormDropdown.FormDropdownProps): Callback = {
     val enums = ddp.value
       .asInstanceOf[js.Array[String]]
       .toSet
@@ -122,5 +123,5 @@ final case class EnumViewMultipleSelect[F[_], A](
     value.set(enums).runInCB
   }
 
-  def getter = value.get.map(i => enum.tag(i)).toJSArray
+  override def getter = value.get.map(i => enum.tag(i)).toJSArray
 }

--- a/src/main/scala/gpp/ui/forms/EnumViewOptionalSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewOptionalSelect.scala
@@ -25,17 +25,18 @@ import scalajs.js
 import scalajs.js.|
 
 /**
- * Produces a dropdown menu, similar to a combobox, for which
- * multiple values can be selected.
+ * Produces a dropdown menu, similar to a combobox, for which the
+ * value is optional.
  */
-final case class EnumViewMultipleSelect[F[_], A](
+final case class EnumViewOptionalSelect[F[_], A](
   id:                   String,
-  value:                ViewF[F, Set[A]],
+  value:                ViewF[F, Option[A]],
   as:                   js.UndefOr[AsC] = js.undefined,
   basic:                js.UndefOr[Boolean] = js.undefined,
   button:               js.UndefOr[Boolean] = js.undefined,
   className:            js.UndefOr[String] = js.undefined,
   clazz:                js.UndefOr[Css] = js.undefined,
+  clearable:            js.UndefOr[Boolean] = js.undefined,
   closeOnBlur:          js.UndefOr[Boolean] = js.undefined,
   closeOnEscape:        js.UndefOr[Boolean] = js.undefined,
   closeOnChange:        js.UndefOr[Boolean] = js.undefined,
@@ -107,20 +108,18 @@ final case class EnumViewMultipleSelect[F[_], A](
     with EnumViewSelectBase {
 
   type AA    = A
-  type BB    = Set[A]
+  type BB    = Option[A]
   type FF[X] = F[X]
 
-  val clearable = false
-  val multiple  = true
+  val multiple = false
 
-  def withMods(mods: TagMod*): EnumViewMultipleSelect[F, A] = copy(modifiers = modifiers ++ mods)
-  def setter(ddp: FormDropdown.FormDropdownProps): Callback = {
-    val enums = ddp.value
-      .asInstanceOf[js.Array[String]]
-      .toSet
-      .flatMap(v => enum.fromTag(v))
-    value.set(enums).runInCB
-  }
+  def withMods(mods: TagMod*): EnumViewOptionalSelect[F, A]    = copy(modifiers = modifiers ++ mods)
+  def setter(ddp:    FormDropdown.FormDropdownProps): Callback =
+    ddp.value.toOption
+      .flatMap(v => enum.fromTag(v.asInstanceOf[String]))
+      .map(v => value.set(Some(v)).runInCB)
+      .getOrEmpty
 
-  def getter = value.get.map(i => enum.tag(i)).toJSArray
+  // sets the value of the underlying select from the ViewF[F, B]
+  def getter = value.get.map(i => enum.tag(i)).orUndefined
 }

--- a/src/main/scala/gpp/ui/forms/EnumViewOptionalSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewOptionalSelect.scala
@@ -108,18 +108,19 @@ final case class EnumViewOptionalSelect[F[_], A](
     with EnumViewSelectBase {
 
   type AA    = A
-  type BB    = Option[A]
+  type GG[X] = Option[X]
   type FF[X] = F[X]
 
-  val multiple = false
+  override val multiple = false
 
-  def withMods(mods: TagMod*): EnumViewOptionalSelect[F, A]    = copy(modifiers = modifiers ++ mods)
-  def setter(ddp:    FormDropdown.FormDropdownProps): Callback =
+  def withMods(mods: TagMod*): EnumViewOptionalSelect[F, A] = copy(modifiers = modifiers ++ mods)
+
+  override def setter(ddp: FormDropdown.FormDropdownProps): Callback =
     ddp.value.toOption
       .flatMap(v => enum.fromTag(v.asInstanceOf[String]))
       .map(v => value.set(Some(v)).runInCB)
       .getOrEmpty
 
   // sets the value of the underlying select from the ViewF[F, B]
-  def getter = value.get.map(i => enum.tag(i)).orUndefined
+  override def getter = value.get.map(i => enum.tag(i)).orUndefined
 }

--- a/src/main/scala/gpp/ui/forms/EnumViewSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewSelect.scala
@@ -4,35 +4,32 @@
 package lucuma.ui.forms
 
 import cats.effect.Effect
-import cats.syntax.all._
-import crystal.ViewOptF
+import crystal.ViewF
 import crystal.react.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.syntax.all._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
 import react.semanticui.collections.form.FormDropdown
-import react.semanticui.collections.form.FormSelect
 import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.label.Label
 import react.semanticui.modules.dropdown.Dropdown._
 import react.semanticui.modules.dropdown._
 
-import scalajs.js.JSConverters._
 import scalajs.js
 import scalajs.js.|
 
 /**
- * Produces a dropdown menu, similar to a combobox
+ * Produces a dropdown menu, similar to a combobox, for which the
+ * value is required.
  */
 final case class EnumViewSelect[F[_], A](
   id:                   String,
-  value:                ViewOptF[F, A],
+  value:                ViewF[F, A],
   as:                   js.UndefOr[AsC] = js.undefined,
   basic:                js.UndefOr[Boolean] = js.undefined,
   button:               js.UndefOr[Boolean] = js.undefined,
@@ -47,7 +44,6 @@ final case class EnumViewSelect[F[_], A](
   defaultSearchQuery:   js.UndefOr[String] = js.undefined,
   defaultSelectedLabel: js.UndefOr[JsNumber | String] = js.undefined,
   defaultUpward:        js.UndefOr[Boolean] = js.undefined,
-  defaultValue:         js.UndefOr[A] = js.undefined,
   direction:            js.UndefOr[Direction] = js.undefined,
   disabled:             js.UndefOr[Boolean] = js.undefined,
   error:                js.UndefOr[Boolean] = js.undefined,
@@ -82,7 +78,6 @@ final case class EnumViewSelect[F[_], A](
   onSearchChangeE:      js.UndefOr[OnSearchChangeE] = js.undefined,
   open:                 js.UndefOr[Boolean] = js.undefined,
   openOnFocus:          js.UndefOr[Boolean] = js.undefined,
-  placeholder:          js.UndefOr[String] = js.undefined,
   pointing:             js.UndefOr[Pointing] = js.undefined,
   renderLabel:          js.UndefOr[RenderLabel] = js.undefined,
   required:             js.UndefOr[Boolean] = js.undefined,
@@ -106,112 +101,23 @@ final case class EnumViewSelect[F[_], A](
   val enum:             Enumerated[A],
   val display:          Display[A],
   val effect:           Effect[F]
-) extends ReactProps[EnumViewSelect[Any, Any]](EnumViewSelect.component) {
-  def withMods(mods: TagMod*): EnumViewSelect[F, A] = copy(modifiers = modifiers ++ mods)
-}
+) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
+    with EnumViewSelectBase {
 
-object EnumViewSelect {
-  type Props[F[_], A] = EnumViewSelect[F, A]
+  type AA    = A
+  type BB    = A
+  type FF[X] = F[X]
 
-  protected val component =
-    ScalaComponent
-      .builder[Props[Any, Any]]
-      .stateless
-      .render_P { p =>
-        implicit val display = p.display
-        implicit val effect  = p.effect
+  val clearable   = false
+  val multiple    = false
+  val placeholder = js.undefined
 
-        FormSelect(
-          additionLabel = js.undefined,
-          additionPosition = js.undefined,
-          allowAdditions = js.undefined,
-          p.as,
-          p.basic,
-          p.button,
-          p.className,
-          p.clazz,
-          clearable = false,
-          p.closeOnBlur,
-          p.closeOnEscape,
-          p.closeOnChange,
-          p.compact,
-          content = js.undefined,
-          control = js.undefined,
-          p.deburr,
-          p.defaultOpen,
-          p.defaultSearchQuery,
-          p.defaultSelectedLabel,
-          p.defaultUpward,
-          p.defaultValue.map(i => p.enum.tag(i)),
-          p.direction,
-          p.disabled,
-          p.error,
-          p.floating,
-          p.fluid,
-          p.header,
-          p.icon,
-          p.inline,
-          p.item,
-          p.label,
-          p.labeled,
-          lazyLoad = false,
-          p.loading,
-          p.minCharacters,
-          multiple = false,
-          p.noResultsMessage,
-          onAddItem = js.undefined,
-          p.onBlur,
-          p.onBlurE,
-          onChange = js.undefined,
-          (e: ReactEvent, ddp: FormDropdown.FormDropdownProps) =>
-            ddp.value.toOption
-              .flatMap(v => p.enum.fromTag(v.asInstanceOf[String]))
-              .map(v => p.value.set(v).runInCB)
-              .getOrEmpty
-              >> p.onChangeE
-                .map(_(e, ddp))
-                .toOption
-                .orElse(p.onChange.map(_(ddp)).toOption)
-                .getOrEmpty,
-          p.onClick,
-          p.onClickE,
-          p.onClose,
-          p.onCloseE,
-          p.onFocus,
-          p.onFocusE,
-          p.onLabelClick,
-          p.onLabelClickE,
-          p.onMouseDown,
-          p.onMouseDownE,
-          p.onOpen,
-          p.onOpenE,
-          p.onSearchChange,
-          p.onSearchChangeE,
-          p.open,
-          p.openOnFocus,
-          options = p.enum.all.map(i => DropdownItem(text = i.shortName, value = p.enum.tag(i))),
-          p.placeholder,
-          p.pointing,
-          p.renderLabel,
-          p.required,
-          p.scrolling,
-          p.search,
-          p.searchInput,
-          p.searchQuery,
-          p.selectOnBlur,
-          p.selectOnNavigation,
-          p.selectedLabel,
-          p.simple,
-          p.tabIndex,
-          p.text,
-          p.tpe,
-          p.trigger,
-          p.upward,
-          p.value.get.map(i => p.enum.tag(i)).orUndefined,
-          p.width,
-          p.wrapSelection,
-          p.modifiers :+ (^.id := p.id)
-        )
-      }
-      .build
+  def withMods(mods: TagMod*): EnumViewSelect[F, A]            = copy(modifiers = modifiers ++ mods)
+  def setter(ddp:    FormDropdown.FormDropdownProps): Callback =
+    ddp.value.toOption
+      .flatMap(v => enum.fromTag(v.asInstanceOf[String]))
+      .map(v => value.set(v).runInCB)
+      .getOrEmpty
+
+  def getter = enum.tag(value.get)
 }

--- a/src/main/scala/gpp/ui/forms/EnumViewSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewSelect.scala
@@ -3,6 +3,7 @@
 
 package lucuma.ui.forms
 
+import cats.Id
 import cats.effect.Effect
 import crystal.ViewF
 import crystal.react.implicits._
@@ -29,7 +30,7 @@ import scalajs.js.|
  */
 final case class EnumViewSelect[F[_], A](
   id:                   String,
-  value:                ViewF[F, A],
+  value:                ViewF[F, Id[A]],
   as:                   js.UndefOr[AsC] = js.undefined,
   basic:                js.UndefOr[Boolean] = js.undefined,
   button:               js.UndefOr[Boolean] = js.undefined,
@@ -105,19 +106,20 @@ final case class EnumViewSelect[F[_], A](
     with EnumViewSelectBase {
 
   type AA    = A
-  type BB    = A
+  type GG[X] = Id[A]
   type FF[X] = F[X]
 
-  val clearable   = false
-  val multiple    = false
-  val placeholder = js.undefined
+  override val clearable   = false
+  override val multiple    = false
+  override val placeholder = js.undefined
 
-  def withMods(mods: TagMod*): EnumViewSelect[F, A]            = copy(modifiers = modifiers ++ mods)
-  def setter(ddp:    FormDropdown.FormDropdownProps): Callback =
+  def withMods(mods: TagMod*): EnumViewSelect[F, A] = copy(modifiers = modifiers ++ mods)
+
+  override def setter(ddp: FormDropdown.FormDropdownProps): Callback =
     ddp.value.toOption
       .flatMap(v => enum.fromTag(v.asInstanceOf[String]))
       .map(v => value.set(v).runInCB)
       .getOrEmpty
 
-  def getter = enum.tag(value.get)
+  override def getter = enum.tag(value.get)
 }

--- a/src/main/scala/gpp/ui/forms/EnumViewSelectBase.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewSelectBase.scala
@@ -30,10 +30,10 @@ import scalajs.js.|
 trait EnumViewSelectBase {
   type FF[_]
   type AA
-  type BB
+  type GG[_]
 
   val id: String
-  val value: ViewF[FF, BB]
+  val value: ViewF[FF, GG[AA]]
   val as: js.UndefOr[AsC]
   val basic: js.UndefOr[Boolean]
   val button: js.UndefOr[Boolean]

--- a/src/main/scala/gpp/ui/forms/EnumViewSelectBase.scala
+++ b/src/main/scala/gpp/ui/forms/EnumViewSelectBase.scala
@@ -1,0 +1,217 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.forms
+
+import cats.syntax.all._
+import crystal.ViewF
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.syntax.all._
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+import react.common._
+import react.semanticui._
+import react.semanticui.collections.form.FormDropdown
+import react.semanticui.collections.form.FormSelect
+import react.semanticui.elements.icon.Icon
+import react.semanticui.elements.label.Label
+import react.semanticui.modules.dropdown.Dropdown._
+import react.semanticui.modules.dropdown._
+
+import scalajs.js
+import scalajs.js.|
+
+/**
+ * Produces a dropdown menu, similar to a combobox.
+ * This is a base trait for various styles.
+ */
+trait EnumViewSelectBase {
+  type FF[_]
+  type AA
+  type BB
+
+  val id: String
+  val value: ViewF[FF, BB]
+  val as: js.UndefOr[AsC]
+  val basic: js.UndefOr[Boolean]
+  val button: js.UndefOr[Boolean]
+  val className: js.UndefOr[String]
+  val clazz: js.UndefOr[Css]
+  val clearable: js.UndefOr[Boolean]
+  val closeOnBlur: js.UndefOr[Boolean]
+  val closeOnEscape: js.UndefOr[Boolean]
+  val closeOnChange: js.UndefOr[Boolean]
+  val compact: js.UndefOr[Boolean]
+  val deburr: js.UndefOr[Boolean]
+  val defaultOpen: js.UndefOr[Boolean]
+  val defaultSearchQuery: js.UndefOr[String]
+  val defaultSelectedLabel: js.UndefOr[JsNumber | String]
+  val defaultUpward: js.UndefOr[Boolean]
+  val direction: js.UndefOr[Direction]
+  val disabled: js.UndefOr[Boolean]
+  val error: js.UndefOr[Boolean]
+  val floating: js.UndefOr[Boolean]
+  val fluid: js.UndefOr[Boolean]
+  val header: js.UndefOr[ShorthandS[VdomNode]]
+  val icon: js.UndefOr[ShorthandS[Icon]]
+  val inline: js.UndefOr[Boolean]
+  val item: js.UndefOr[Boolean]
+  val label: js.UndefOr[ShorthandS[Label]]
+  val labeled: js.UndefOr[Boolean]
+  val loading: js.UndefOr[Boolean]
+  val minCharacters: js.UndefOr[JsNumber]
+  val multiple: js.UndefOr[Boolean]
+  val noResultsMessage: js.UndefOr[ShorthandS[VdomNode]]
+  val onBlur: js.UndefOr[Callback]
+  val onBlurE: js.UndefOr[OnBlur]
+  val onClick: js.UndefOr[Callback]
+  val onClickE: js.UndefOr[OnClick]
+  val onChange: js.UndefOr[FormDropdown.OnChange]
+  val onChangeE: js.UndefOr[FormDropdown.OnChangeE]
+  val onClose: js.UndefOr[Callback]
+  val onCloseE: js.UndefOr[OnClose]
+  val onFocus: js.UndefOr[Callback]
+  val onFocusE: js.UndefOr[OnFocus]
+  val onLabelClick: js.UndefOr[Callback]
+  val onLabelClickE: js.UndefOr[OnLabelClick]
+  val onMouseDown: js.UndefOr[Callback]
+  val onMouseDownE: js.UndefOr[OnMouseDown]
+  val onOpen: js.UndefOr[Callback]
+  val onOpenE: js.UndefOr[OnOpen]
+  val onSearchChange: js.UndefOr[OnSearchChange]
+  val onSearchChangeE: js.UndefOr[OnSearchChangeE]
+  val open: js.UndefOr[Boolean]
+  val openOnFocus: js.UndefOr[Boolean]
+  val placeholder: js.UndefOr[String]
+  val pointing: js.UndefOr[Pointing]
+  val renderLabel: js.UndefOr[RenderLabel]
+  val required: js.UndefOr[Boolean]
+  val scrolling: js.UndefOr[Boolean]
+  val search: js.UndefOr[Boolean | SearchFunction]
+  val searchInput: js.UndefOr[ShorthandS[VdomNode]]
+  val searchQuery: js.UndefOr[String]
+  val selectOnBlur: js.UndefOr[Boolean]
+  val selectOnNavigation: js.UndefOr[Boolean]
+  val selectedLabel: js.UndefOr[JsNumber | String]
+  val simple: js.UndefOr[Boolean]
+  val tabIndex: js.UndefOr[String | JsNumber]
+  val text: js.UndefOr[String]
+  val tpe: js.UndefOr[String]
+  val trigger: js.UndefOr[VdomNode]
+  val upward: js.UndefOr[Boolean]
+  val width: js.UndefOr[SemanticWidth]
+  val wrapSelection: js.UndefOr[Boolean]
+  val modifiers: Seq[TagMod]
+  val enum: Enumerated[AA]
+  val display: Display[AA]
+
+  // set the value in the View from the Select
+  def setter(ddp: FormDropdown.FormDropdownProps): Callback
+
+  // get the value from the View for setting the Select
+  def getter: js.UndefOr[Dropdown.Value]
+}
+
+object EnumViewSelectBase {
+  type Props = EnumViewSelectBase
+
+  private[forms] val component =
+    ScalaComponent
+      .builder[Props]
+      .stateless
+      .render_P { p =>
+        implicit val display = p.display
+
+        FormSelect(
+          additionLabel = js.undefined,
+          additionPosition = js.undefined,
+          allowAdditions = js.undefined,
+          p.as,
+          p.basic,
+          p.button,
+          p.className,
+          p.clazz,
+          p.clearable,
+          p.closeOnBlur,
+          p.closeOnEscape,
+          p.closeOnChange,
+          p.compact,
+          content = js.undefined,
+          control = js.undefined,
+          p.deburr,
+          p.defaultOpen,
+          p.defaultSearchQuery,
+          p.defaultSelectedLabel,
+          p.defaultUpward,
+          defaultValue = js.undefined,
+          p.direction,
+          p.disabled,
+          p.error,
+          p.floating,
+          p.fluid,
+          p.header,
+          p.icon,
+          p.inline,
+          p.item,
+          p.label,
+          p.labeled,
+          lazyLoad = false,
+          p.loading,
+          p.minCharacters,
+          p.multiple,
+          p.noResultsMessage,
+          onAddItem = js.undefined,
+          p.onBlur,
+          p.onBlurE,
+          onChange = js.undefined,
+          (e: ReactEvent, ddp: FormDropdown.FormDropdownProps) =>
+            p.setter(ddp)
+              >> p.onChangeE
+                .map(_(e, ddp))
+                .toOption
+                .orElse(p.onChange.map(_(ddp)).toOption)
+                .getOrEmpty,
+          p.onClick,
+          p.onClickE,
+          p.onClose,
+          p.onCloseE,
+          p.onFocus,
+          p.onFocusE,
+          p.onLabelClick,
+          p.onLabelClickE,
+          p.onMouseDown,
+          p.onMouseDownE,
+          p.onOpen,
+          p.onOpenE,
+          p.onSearchChange,
+          p.onSearchChangeE,
+          p.open,
+          p.openOnFocus,
+          options = p.enum.all.map(i => DropdownItem(text = i.shortName, value = p.enum.tag(i))),
+          p.placeholder,
+          p.pointing,
+          p.renderLabel,
+          p.required,
+          p.scrolling,
+          p.search,
+          p.searchInput,
+          p.searchQuery,
+          p.selectOnBlur,
+          p.selectOnNavigation,
+          p.selectedLabel,
+          p.simple,
+          p.tabIndex,
+          p.text,
+          p.tpe,
+          p.trigger,
+          p.upward,
+          value = p.getter,
+          p.width,
+          p.wrapSelection,
+          p.modifiers :+ (^.id := p.id)
+        )
+      }
+      .build
+}


### PR DESCRIPTION
Also refactors all EnumView*Select classes to use a trait and common object.

The tricky bit, for me, was getting the type parameters in the concrete classes to match up properly with the type members in the trait. It was easy once I figured it out, but it took me a bit. The `type FF[X] = F[X]` was the final piece of the puzzle.
