### PR TITLE
Allow for limiting and/or modifying text in inputs.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val lucumaCoreVersion      = "0.6.4"
 lazy val monocleVersion         = "2.1.0"
 lazy val crystalVersion         = "0.8.1"
 lazy val catsVersion            = "2.2.0"
+lazy val mouseVersion           = "0.25"
 lazy val reactCommonVersion     = "0.11.0"
 lazy val reactSemanticUIVersion = "0.9.0"
 lazy val kindProjectorVersion   = "0.11.0"
@@ -108,7 +109,8 @@ lazy val ui =
         "io.github.cquiroz.react"           %%% "common"            % reactCommonVersion,
         "io.github.cquiroz.react"           %%% "react-semantic-ui" % reactSemanticUIVersion,
         "com.github.julien-truffaut"        %%% "monocle-core"      % monocleVersion,
-        "com.rpiaggio"                      %%% "crystal"           % crystalVersion
+        "com.rpiaggio"                      %%% "crystal"           % crystalVersion,
+        "org.typelevel"                     %%% "mouse"             % mouseVersion
       ),
       addCompilerPlugin(
         ("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full)

--- a/modules/ui/src/main/scala/lucuma/ui/forms/ChangeAuditor.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/ChangeAuditor.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.forms
+
+import cats.syntax.all._
+import lucuma.core.math._
+import mouse.all._
+
+sealed trait AuditResult[A] extends Product with Serializable
+object AuditResult {
+  case class Reject[A]() extends AuditResult[A]
+  case class Accept[A](newA: Option[A]) extends AuditResult[A]
+  case class NewString[A](newS: String, newA: Option[A], cursorOffset: Int) extends AuditResult[A]
+
+  def reject[A]: AuditResult[A] = Reject()
+  def accept[A](newA:    Option[A]): AuditResult[A] = Accept(newA)
+  def newString[A](newS: String, newA: Option[A], cursorOffset: Int = 0): AuditResult[A] =
+    NewString(newS, newA, cursorOffset)
+}
+
+object ChangeAuditor {
+  def fromFormat[A]: ChangeAuditor[A] = (s, f) =>
+    f.getOption(s).fold(AuditResult.reject[A])(newA => AuditResult.accept(newA.some))
+
+  def defaultForNonNegInts[A]: ChangeAuditor[A] = (s, f) => {
+    val newS = if (s == "") "0" else s
+    fromFormat(newS, f)
+    // TODO: Strip leading zeros if there are non-zeros?
+  }
+
+  // can be used by regular and refined Ints.
+  def defaultForInts[A]: ChangeAuditor[A] = (s, f) => {
+    val newS = s match {
+      case ""  => "0"
+      case "-" => "-0"
+      case _   => s
+    }
+    fromFormat(newS, f)
+  }
+
+  def int(min: Int = Int.MinValue, max: Int = Int.MaxValue): ChangeAuditor[Int] = (s, f) => {
+    def inRange(i: Int) = i >= min && i <= max
+    val vetted = defaultForInts(s, f)
+    vetted match {
+      case AuditResult.Accept(Some(i)) if inRange(i)          => vetted
+      case AuditResult.NewString(_, Some(i), _) if inRange(i) => vetted
+      case _                                                  => AuditResult.reject
+    }
+  }
+
+  def nonNegativeInt(max: Int = Int.MaxValue): ChangeAuditor[Int] = (s, f) => {
+    def inRange(i: Int) = i >= 0 && i <= max
+    val vetted = defaultForNonNegInts(s, f)
+    vetted match {
+      case AuditResult.Accept(Some(i)) if inRange(i)          => vetted
+      case AuditResult.NewString(_, Some(i), _) if inRange(i) => vetted
+      case _                                                  => AuditResult.reject
+    }
+  }
+
+  val useFormattedValue: ChangeAuditor[String] = (s, f) =>
+    f.getOption(s)
+      .fold(AuditResult.reject[String])(newS => AuditResult.newString(newS, newS.some))
+
+  val rightAscension: ChangeAuditor[RightAscension] =
+    (str, format) => {
+      def validateHoursOrMins(hours: String): Option[Unit] =
+        if (hours == "") ().some
+        else
+          """^\d{1,2}""".r.matches(hours).option(()) *>
+            hours.parseIntOption.flatMap(i => if (i >= 0 && i <= 60) ().some else None)
+
+      def validateSeconds(seconds: String): Option[Unit] =
+        // TODO: Validate number of decimal places, strip trailing zeros
+        if (seconds == "") ().some
+        else
+          seconds.parseDoubleOption.flatMap(d => if (d >= 0.0 && d <= 60.0) ().some else None)
+
+      val isValid = {
+        str.split(":").toList match {
+          case Nil                                => ().some // should never get
+          case hours :: Nil                       =>
+            validateHoursOrMins(hours)
+          case hours :: minutes :: Nil            =>
+            validateHoursOrMins(hours) *> validateHoursOrMins(minutes)
+          case hours :: minutes :: seconds :: Nil =>
+            validateHoursOrMins(hours) *> validateHoursOrMins(minutes) *> validateSeconds(seconds)
+          case _                                  => None
+        }
+      }.fold(false)(_ => true)
+
+      if (isValid)
+        format
+          .getOption(str)
+          .fold(AuditResult.accept[RightAscension](None))(r => AuditResult.accept(r.some))
+      else
+        AuditResult.reject
+    }
+}

--- a/modules/ui/src/main/scala/lucuma/ui/forms/FormInputEV.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/FormInputEV.scala
@@ -7,20 +7,25 @@ import scala.scalajs.js
 import scala.scalajs.js.|
 
 import cats.syntax.all._
-import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react._
 import japgolly.scalajs.react.MonocleReact._
-import japgolly.scalajs.react.ReactEventFromInput
-import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import monocle.macros.Lenses
+import org.scalajs.dom.html
 import react.common._
 import react.semanticui._
 import react.semanticui.collections.form.FormInput
 import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.input._
 import react.semanticui.elements.label._
+
+trait UpdateValue extends Product with Serializable
+object UpdateValue {
+  case object OnChange extends UpdateValue
+  case object OnBlur   extends UpdateValue
+}
 
 /**
  * FormInput component that uses an ExternalValue to share the content of the field
@@ -57,16 +62,15 @@ final case class FormInputEV[EV[_], A](
   modifiers:       Seq[TagMod] = Seq.empty,
   onChange:        FormInputEV.ChangeCallback[A] =
     (_: A) => Callback.empty, // callback for parents of this component
-  onBlur:          FormInputEV.ChangeCallback[A] = (_: A) => Callback.empty
+  onBlur:          FormInputEV.ChangeCallback[A] = (_: A) => Callback.empty,
+  changeAuditor:   ChangeAuditor[A] = ChangeAuditor.fromFormat[A],
+  updateOn:        UpdateValue = UpdateValue.OnChange
 )(implicit val ev: ExternalValue[EV])
     extends ReactProps[FormInputEV[Any, Any]](FormInputEV.component) {
-  def valGet: String = ev.get(value).foldMap(format.reverseGet)
-  def valSet(s: String): Callback =
-    format.getOption(s).map(ev.set(value)).getOrEmpty
-  val onBlurC: InputEV.ChangeCallback[String]   =
-    (s: String) => format.getOption(s).map(onBlur).getOrEmpty
-  val onChangeC: InputEV.ChangeCallback[String] =
-    (s: String) => format.getOption(s).map(onChange).getOrEmpty
+  def valGet: String                       = ev.get(value).foldMap(format.reverseGet)
+  def valSet: A => Callback                = ev.set(value)
+  def onBlurC: InputEV.ChangeCallback[A]   = (a: A) => onBlur(a)
+  val onChangeC: InputEV.ChangeCallback[A] = onChange
 
   def withMods(mods: TagMod*): FormInputEV[EV, A] = copy(modifiers = modifiers ++ mods)
 }
@@ -77,36 +81,73 @@ object FormInputEV {
   type Scope[EV[_], A]   = RenderScope[Props[EV, A], State, Unit]
 
   @Lenses
-  final case class State(curValue: String, prevValue: String)
+  final case class State(displayValue: String, modelValue: String, cursor: Option[(Int, Int)])
 
-  def onTextChange[EV[_], A]($ : Scope[EV, A]): ReactEventFromInput => Callback =
-    (e: ReactEventFromInput) => {
-      // Capture the value outside setState, react reuses the events
-      val v = e.target.value
-      // First update the internal state, then call the outside listener
-      $.setStateL(State.curValue)(v) *>
-        // Next 2 might not be called if the InputFormat returns None
-        $.props.valSet(v) *>
-        $.props.onChangeC(v)
-    }
+  class Backend[EV[_], A]($ : BackendScope[Props[EV, A], State]) {
+    private val outerRef = Ref[html.Element]
 
-  def onBlur[EV[_], A]($ : Scope[EV, A], c: ChangeCallback[String]): Callback =
-    c($.state.curValue)
+    def getInputElement(e: html.Element): html.Input =
+      e.firstChild
+        .asInstanceOf[html.Element]
+        .childNodes(1)
+        .asInstanceOf[html.Element]
+        .firstChild
+        .asInstanceOf[html.Input]
 
-  protected val component =
-    ScalaComponent
-      .builder[Props[Any, Any]]
-      .getDerivedStateFromPropsAndState[State] { (props, stateOpt) =>
-        val newValue = props.valGet
-        // Force new value from props if the prop changes (or we are initializing).
-        stateOpt match {
-          case Some(state) if newValue === state.prevValue => state
-          case _                                           => State(newValue, newValue)
+    def getCursor: CallbackTo[Option[(Int, Int)]] =
+      outerRef.get.map(getInputElement).map(i => (i.selectionStart, i.selectionEnd)).asCallback
+
+    def setCursor(cursor: (Int, Int)): Callback =
+      outerRef.get.map(getInputElement).map(i => i.setSelectionRange(cursor._1, cursor._2))
+
+    def setStateCursor(offset: Int): Callback =
+      getCursor
+        .map(oc => oc.map { case (start, end) => (start + offset, end + offset) })
+        .flatMap(oc => $.setStateL(State.cursor)(oc))
+
+    def clearStateCursor: Callback = $.setStateL(State.cursor)(None)
+
+    def setCursorFromState: Callback =
+      $.state.flatMap(s => s.cursor.map(setCursor).getOrElse(Callback.empty))
+
+    def onTextChange: ReactEventFromInput => Callback =
+      (e: ReactEventFromInput) => {
+        $.props.flatMap { props =>
+          // Capture the value outside setState, react reuses the events
+          val v = e.target.value
+
+          def setDisplayValue(s: String): Callback    = $.setStateL(State.displayValue)(s)
+          def setModelValue(oa:  Option[A]): Callback =
+            if (props.updateOn == UpdateValue.OnChange)
+              oa.fold(Callback.empty)(a =>
+                // Set both state.modelValue and props.value so we don't reset state when we don't want to
+                $.setStateL(State.modelValue)(props.format.reverseGet(a)) *>
+                  props.valSet(a) *> props.onChange(a)
+              )
+            else Callback.empty
+
+          val result = props.changeAuditor(v, props.format)
+          result match {
+            case AuditResult.Accept(oa)                  =>
+              clearStateCursor *> setDisplayValue(v) *> setModelValue(oa)
+            case AuditResult.NewString(newS, oa, offset) =>
+              setStateCursor(offset) *> setDisplayValue(newS) *> setModelValue(oa)
+            case AuditResult.Reject()                    => setStateCursor(-1)
+          }
         }
       }
-      .render { $ =>
-        val p = $.props
-        val s = $.state
+
+    def onBlur(c: ChangeCallback[A]): Callback = for {
+      s  <- $.state
+      v   = s.displayValue
+      p  <- $.props
+      cb <- p.format.getOption(v).map(a => p.valSet(a) *> c(a)).getOrEmpty
+    } yield cb
+
+    val OuterDiv = <.div()
+
+    def render(p: Props[EV, A], s: State) =
+      OuterDiv.withRef(outerRef)(
         FormInput(
           p.action,
           p.actionPosition,
@@ -128,17 +169,34 @@ object FormInputEV {
           p.labelPosition,
           p.loading,
           js.undefined,
-          onTextChange($),
+          onTextChange,
           p.required,
           p.size,
           p.tabIndex,
           p.tpe,
           p.transparent,
           p.width,
-          s.curValue
+          s.displayValue
         )(
-          (p.modifiers :+ (^.id := p.id) :+ (^.onBlur --> onBlur($, p.onBlurC)): _*)
+          (p.modifiers :+ (^.id := p.id) :+ (^.onBlur --> onBlur(p.onBlurC)): _*)
         )
+      )
+
+  }
+
+  protected val component =
+    ScalaComponent
+      .builder[Props[Any, Any]]
+      .getDerivedStateFromPropsAndState[State] { (props, stateOpt) =>
+        val newValue = props.valGet
+        // Force new value from props if the exernal value changes externally
+        // (or we are initializing).
+        stateOpt match {
+          case Some(state) if newValue === state.modelValue => state
+          case _                                            => State(newValue, newValue, None)
+        }
       }
+      .renderBackend[Backend[Any, Any]]
+      .componentDidUpdate(_.backend.setCursorFromState)
       .build
 }

--- a/modules/ui/src/main/scala/lucuma/ui/forms/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/package.scala
@@ -7,4 +7,6 @@ import lucuma.core.optics.Format
 
 package object forms {
   type InputFormat[A] = Format[String, A]
+
+  type ChangeAuditor[A] = (String, InputFormat[A]) => AuditResult[A]
 }

--- a/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
@@ -3,6 +3,7 @@
 
 package lucuma.ui
 
+import coulomb.Quantity
 import eu.timepit.refined.api.RefType
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
@@ -48,6 +49,14 @@ trait RefinedReusabiltyInstances {
 }
 
 /**
+ * Generic reusability of coulomb quantities
+ */
+trait CoulombReusabilityInstance {
+  implicit def quantityReuse[N: Reusability, U]: Reusability[Quantity[N, U]] =
+    Reusability.by(_.value)
+}
+
+/**
  * Reusability instances for model classes
  */
 trait ModelReusabiltyInstances
@@ -68,3 +77,4 @@ package object reusability
     extends UtilReusabilityInstances
     with MathReusabilityInstances
     with ModelReusabiltyInstances
+    with CoulombReusabilityInstance


### PR DESCRIPTION
It's not complete, but I think it's in a good enough state to share.

I found a solution to the problem of the cursor moving to the end. It required getting access to a` Ref` and updating the cursor position when needed.

I created a `ChangeAuditor`, which is just a function that returns an `AuditResult` that the OnChange handler uses to accept, reject or update the text in the input. I opted to keep the `Format` separate because I think they are fundamentally different tasks. The ChangeAuditor has access to the Format and can use it as it requires. In the simplest case, the `fromFormat` ChangeAuditor  just uses the Format to determine validity.

Raúl's validation ideas can be incorporated in this pretty easily. I would just have `Validator` be similar to the `ChangeAuditor`, but with the task of preparing and presenting validation messages. By keeping `Format`, `ChangeAuditor` and `Validator` separate, it would be easy to mix and match as needed. For example, in one instance you may want to allow the user to enter any integer, but present an error if it is out of range. In other cases, you may want to limit the input so that it is always valid.

I also made it possible to choose between updating the model in OnChange (any time it is valid), or updating it only on blur. I can see use cases for both. 