### PR TITLE
Validation errors are NES. Custom errors too.

### DIFF
--- a/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
+++ b/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
@@ -25,6 +25,8 @@ import monocle.macros.Lenses
 import org.scalajs.dom
 import japgolly.scalajs.react.MonocleReact._
 import eu.timepit.refined.cats._
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.auto._
 
 final case class FormComponent(root: ViewF[IO, RootModel])
     extends ReactProps[FormComponent](FormComponent.component)
@@ -61,10 +63,11 @@ object FormComponent {
               value = $.props.root.zoom(RootModel.field2),
               errorClazz = Css("error-label"),
               errorPointing = LabelPointing.Below,
+              error = NonEmptyString("This is another error"),
               validFormat = ValidFormatInput(
                 s =>
                   if (s.isEmpty)
-                    "Can't be empty".invalidNec
+                    NonEmptyString("Can't be empty").invalidNec
                   else
                     s.toLowerCase.validNec,
                 identity[String]

--- a/modules/ui/src/main/scala/lucuma/ui/forms/FormInputEV.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/FormInputEV.scala
@@ -22,10 +22,10 @@ import react.semanticui.elements.input._
 import react.semanticui.elements.label._
 import cats.data.NonEmptyChain
 import scalajs.js.JSConverters._
-import japgolly.scalajs.react.React
 import cats.data.Validated.Valid
 import cats.data.Validated.Invalid
 import cats.data.ValidatedNec
+import eu.timepit.refined.types.string.NonEmptyString
 
 /**
  * FormInput component that uses an ExternalValue to share the content of the field
@@ -40,7 +40,7 @@ final case class FormInputEV[EV[_], A](
   content:         js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   control:         js.UndefOr[String] = js.undefined,
   disabled:        js.UndefOr[Boolean] = js.undefined,
-  error:           js.UndefOr[ShorthandB[Label]] = js.undefined,
+  error:           js.UndefOr[ShorthandB[NonEmptyString]] = js.undefined,
   errorClazz:      js.UndefOr[Css] = js.undefined,
   errorPointing:   js.UndefOr[LabelPointing] = js.undefined,
   fluid:           js.UndefOr[Boolean] = js.undefined,
@@ -64,8 +64,9 @@ final case class FormInputEV[EV[_], A](
   modifiers:       Seq[TagMod] = Seq.empty,
   onTextChange:    String => Callback = _ => Callback.empty,
   onValidChange:   FormInputEV.ChangeCallback[Boolean] = _ => Callback.empty,
-  onBlur:          FormInputEV.ChangeCallback[ValidatedNec[String, A]] = (_: ValidatedNec[String, A]) =>
-    Callback.empty // for extra actions
+  onBlur:          FormInputEV.ChangeCallback[ValidatedNec[NonEmptyString, A]] =
+    // Only use for extra actions, setting should be done through value.set
+    (_: ValidatedNec[NonEmptyString, A]) => Callback.empty
 )(implicit val ev: ExternalValue[EV], val eq: Eq[A])
     extends ReactProps[FormInputEV[Any, Any]](FormInputEV.component) {
 
@@ -81,14 +82,18 @@ object FormInputEV {
   type ChangeCallback[A] = A => Callback
 
   @Lenses
-  final case class State(curValue: String, prevValue: String, errors: Option[NonEmptyChain[String]])
+  final case class State(
+    curValue:  String,
+    prevValue: String,
+    errors:    Option[NonEmptyChain[NonEmptyString]]
+  )
 
   class Backend[EV[_], A]($ : BackendScope[Props[EV, A], State]) {
 
     def validate(
       props: Props[EV, A],
       value: String,
-      cb:    ValidatedNec[String, A] => Callback = _ => Callback.empty
+      cb:    ValidatedNec[NonEmptyString, A] => Callback = _ => Callback.empty
     ): Callback = {
       val validated = props.validFormat.getValidated(value)
       props.onValidChange(validated.isValid) >> cb(validated)
@@ -125,27 +130,28 @@ object FormInputEV {
 
     def render(p: Props[EV, A], s: State): VdomNode = {
 
-      val validationError: js.UndefOr[Label] =
-        s.errors
-          .map(e =>
-            Label(content = e.toList.mkString(","),
-                  clazz = p.errorClazz,
-                  pointing = p.errorPointing
-            )(^.position.absolute)
-          )
-          .orUndefined
+      def errorLabel(errors: NonEmptyChain[NonEmptyString]): js.UndefOr[ShorthandB[Label]] = {
+        val vdoms = errors.toList.map[VdomNode](_.value)
+        val list  = vdoms.head +: vdoms.tail.flatMap[VdomNode](e => List(<.br, <.br, e))
+        Label(
+          content = React.Fragment(list: _*),
+          clazz = p.errorClazz,
+          pointing = p.errorPointing
+        )(
+          ^.position.absolute
+        )
+      }
 
       val error: js.UndefOr[ShorthandB[Label]] = p.error
         .flatMap[ShorthandB[Label]] {
           (_: Any) match {
-            case b: Boolean => validationError.map(_.asInstanceOf[ShorthandB[Label]]).orElse(b)
-            case l: Label   =>
-              validationError
-                .map(vel => Label(content = React.Fragment(l, vel)).asInstanceOf[ShorthandB[Label]])
-                .orElse(l)
+            case b: Boolean => s.errors.map(errorLabel).getOrElse(b)
+            case e          => // We can't pattern match against NonEmptyString, but we know it is one.
+              val nes = e.asInstanceOf[NonEmptyString]
+              s.errors.map(ve => errorLabel(nes +: ve)).getOrElse(errorLabel(NonEmptyChain(nes)))
           }
         }
-        .orElse(validationError)
+        .orElse(s.errors.orUndefined.flatMap(errorLabel))
 
       FormInput(
         p.action,

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
@@ -10,6 +10,8 @@ import monocle.Iso
 import monocle.Prism
 import cats.data.NonEmptyChain
 import cats.data.ValidatedNec
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.auto._
 
 /**
  * Convenience version of `ValidFormat` when the error type is `NonEmptyChain[String]` and `T = String`.
@@ -25,7 +27,7 @@ object ValidFormatInput extends ValidFormatInputInstances {
    * Build optic from getValidated and reverseGet functions.
    */
   def apply[A](
-    getValidated: String => ValidatedNec[String, A],
+    getValidated: String => ValidatedNec[NonEmptyString, A],
     reverseGet:   A => String
   ): ValidFormatInput[A] =
     ValidFormat(getValidated, reverseGet)
@@ -35,7 +37,7 @@ object ValidFormatInput extends ValidFormatInputInstances {
    */
   def fromFormat[A](
     format:       Format[String, A],
-    errorMessage: String = "Invalid format"
+    errorMessage: NonEmptyString = "Invalid format"
   ): ValidFormatInput[A] =
     ValidFormat(
       format.getOption.andThen(o => Validated.fromOption(o, NonEmptyChain(errorMessage))),
@@ -47,7 +49,7 @@ object ValidFormatInput extends ValidFormatInputInstances {
    */
   def fromPrism[A](
     prism:        Prism[String, A],
-    errorMessage: String = "Invalid value"
+    errorMessage: NonEmptyString = "Invalid value"
   ): ValidFormatInput[A] =
     fromFormat(Format.fromPrism(prism), errorMessage)
 
@@ -65,7 +67,7 @@ object ValidFormatInput extends ValidFormatInputInstances {
    */
   def fromFormatOptional[A](
     format:       Format[String, A],
-    errorMessage: String = "Invalid format"
+    errorMessage: NonEmptyString = "Invalid format"
   ): ValidFormatInput[Option[A]] =
     ValidFormatInput(
       (a: String) =>

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
@@ -12,12 +12,15 @@ import eu.timepit.refined.types.string.NonEmptyString
  */
 trait ValidFormatInputInstances {
   val nonEmptyValidFormat = ValidFormatInput[NonEmptyString](
-    s => NonEmptyString.from(s).fold(_ => "Can't be empty".invalidNec, _.validNec),
+    s => NonEmptyString.from(s).fold(_ => NonEmptyString("Can't be empty").invalidNec, _.validNec),
     _.toString
   )
 
   val upperNESValidFormat = ValidFormatInput[UpperNES](
-    s => UpperNES.from(s.toUpperCase).fold(_ => "Can't be empty".invalidNec, s => s.validNec),
+    s =>
+      UpperNES
+        .from(s.toUpperCase)
+        .fold(_ => NonEmptyString("Can't be empty").invalidNec, s => s.validNec),
     _.toString
   )
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/package.scala
@@ -5,9 +5,10 @@ package lucuma.ui
 
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
+import eu.timepit.refined.types.string.NonEmptyString
 
 package object optics {
   type ValidFormatNec[E, T, A] = ValidFormat[NonEmptyChain[E], T, A]
   type ValidFormatNel[E, T, A] = ValidFormat[NonEmptyList[E], T, A]
-  type ValidFormatInput[A]     = ValidFormatNec[String, String, A]
+  type ValidFormatInput[A]     = ValidFormatNec[NonEmptyString, String, A]
 }

--- a/modules/ui/src/main/scala/lucuma/ui/refined/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/refined/package.scala
@@ -4,16 +4,17 @@
 package lucuma.ui
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.char.UpperCase
+import eu.timepit.refined.char.LowerCase
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.collection.Forall
 import eu.timepit.refined.boolean.And
+import eu.timepit.refined.boolean.Not
 
 /**
  * Convenience refined definitions.
  */
 package object refined {
-  type UpperNES = String Refined And[NonEmpty, Forall[UpperCase]]
+  type UpperNES = String Refined And[NonEmpty, Forall[Not[LowerCase]]]
   object UpperNES extends RefinedTypeOps[UpperNES, String]
 }


### PR DESCRIPTION
* Validation errors are now `NonEmptyString`s.
* Passing custom errors to `FormInputEV` is now done via `Boolean | NonEmptyString` instead of `Boolean | Label`. This allows combining with validation errors to show them all in one `Label`.