### PR TITLE
Error-handling crystal.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val FUILess                = "2.8.7"
 lazy val scalaJsReactVersion    = "1.7.7"
 lazy val lucumaCoreVersion      = "0.7.9"
 lazy val monocleVersion         = "2.1.0"
-lazy val crystalVersion         = "0.9.3"
+lazy val crystalVersion         = "0.10.0"
 lazy val catsVersion            = "2.4.2"
 lazy val mouseVersion           = "1.0.0"
 lazy val reactCommonVersion     = "0.11.3"
@@ -62,6 +62,7 @@ lazy val demo =
       Compile / fastOptJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
       Compile / fullOptJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
       test := {},
+      libraryDependencies += "com.rpiaggio" %%% "log4cats-loglevel" % "0.2.0",
       // NPM libs for development, mostly to let webpack do its magic
       Compile / npmDevDependencies ++= Seq(
         "postcss"                       -> "8.1.1",

--- a/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
+++ b/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
@@ -19,6 +19,7 @@ import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.ReusabilityOverlay
 import japgolly.scalajs.react.vdom.html_<^._
+import log4cats.loglevel.LogLevelLogger
 import lucuma.core.math.Declination
 import lucuma.core.math.Epoch
 import lucuma.core.math.RightAscension
@@ -33,6 +34,7 @@ import lucuma.ui.refined._
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import org.scalajs.dom
+import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common.style.Css
 import react.semanticui.collections.form.Form
@@ -43,7 +45,7 @@ import scala.scalajs.js.annotation._
 object types {
   type ZeroTo2048 = Interval.Closed[0, 2048]
 }
-final case class FormComponent(root: ViewF[IO, RootModel])
+final case class FormComponent(root: ViewF[IO, RootModel])(implicit val logger: Logger[IO])
     extends ReactProps[FormComponent](FormComponent.component)
 
 object FormComponent {
@@ -72,6 +74,8 @@ object FormComponent {
       .builder[Props]
       .initialState(State())
       .render { $ =>
+        implicit val logger = $.props.logger
+
         <.div(^.paddingTop := "20px")(
           s"MODEL: ${$.props.root.get}",
           <.br,
@@ -205,7 +209,6 @@ object FormComponent {
       }
       .configure(Reusability.shouldComponentUpdate)
       .build
-
 }
 
 @Lenses
@@ -232,6 +235,8 @@ case class AppContext[F[_]]()(implicit val cs: ContextShift[F])
 object AppCtx extends AppRootContext[AppContext[IO]]
 
 trait AppMain extends IOApp {
+
+  implicit protected val logger: Logger[IO] = LogLevelLogger.createForRoot[IO]
 
   protected def rootComponent(
     view: ViewF[IO, RootModel]

--- a/modules/demo/yarn.lock
+++ b/modules/demo/yarn.lock
@@ -30,17 +30,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@fluentui/react-component-event-listener@~0.51.1":
-  version "0.51.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.2.tgz#bb403c96acfa9fb4ea338f3f2bf66e672085a4c7"
-  integrity sha512-myfDuwU/MRGH5hqldLmwfMAn7FoXCCspdknWg+A0Tyf+mjUsgWlqRewLapon8mJqprZzrH1obPxONV/lVI3Quw==
+"@fluentui/react-component-event-listener@~0.51.6":
+  version "0.51.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz#158adb970d8bc982c91c57fd1322a0036042d86e"
+  integrity sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==
   dependencies:
     "@babel/runtime" "^7.10.4"
 
-"@fluentui/react-component-ref@~0.51.1":
-  version "0.51.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-component-ref/-/react-component-ref-0.51.2.tgz#17d27ce4da914e162a9ac4f3f4a7810d1ade658a"
-  integrity sha512-LE3NXMHJ5K2ZgTf+p/l4cDRYwmfXTw1XhjZLBI0sZaggbaUxMgrfvr0DHvkcZrbr3aLMaILYoQrTjP9Y1w0veA==
+"@fluentui/react-component-ref@~0.51.6":
+  version "0.51.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz#bfb0312e926c213bed35e53ee5105a68732eea99"
+  integrity sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==
   dependencies:
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
@@ -372,15 +372,15 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@popperjs/core@^2.5.2":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
-  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+"@popperjs/core@^2.6.0":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
+  integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@semantic-ui-react/event-stack@^3.1.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz#3263d17511db81a743167fe45281a24b3eb6b3c8"
-  integrity sha512-SA7VOu/tY3OkooR++mm9voeQrJpYXjJaMHO1aFCcSouS2xhqMR9Gnz0LEGLOR0h9ueWPBKaQzKIrx3FTTJZmUQ==
+"@semantic-ui-react/event-stack@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.1.2.tgz#14fac9796695aa3967962d94ea9733a85325f9c4"
+  integrity sha512-Yd0Qf7lPCIjzJ9bZYfurlNu2RDXT6KKSyubHfYK3WjRauhxCsq6Fk2LMRI9DEvShoEU+AsLSv3NGkqXAcVp0zg==
   dependencies:
     exenv "^1.2.2"
     prop-types "^15.6.2"
@@ -4017,6 +4017,11 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+loglevel@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
+
 loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
@@ -5600,15 +5605,20 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-is@^16.6.3, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.6.3, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-popper@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+"react-is@^16.8.6 || ^17.0.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-popper@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
+  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
@@ -5963,23 +5973,23 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "^0.10.0"
 
-semantic-ui-react@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-2.0.0.tgz#72f17837d3bf680b73cc39c90a6593847c18e3c3"
-  integrity sha512-LDik4s+Qbud1SapBdygFfgP5Q1tmmdScuRL1wwxjpDv1TENEwSSX1wDislrsk+HhjYYjkoIB9tt7psD/RAb1CQ==
+semantic-ui-react@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-2.0.3.tgz#39091e24078e28129ff9b1beb7dbfc84ca85544b"
+  integrity sha512-a0hGN6XXw64sRSKwWqMCKSI/AGLohxNeWuErS39eswvBbUnLjBij8ZoEdiqDiz/PuWpwYIRjgmQVrut+7h3b2g==
   dependencies:
     "@babel/runtime" "^7.10.5"
-    "@fluentui/react-component-event-listener" "~0.51.1"
-    "@fluentui/react-component-ref" "~0.51.1"
-    "@popperjs/core" "^2.5.2"
-    "@semantic-ui-react/event-stack" "^3.1.0"
+    "@fluentui/react-component-event-listener" "~0.51.6"
+    "@fluentui/react-component-ref" "~0.51.6"
+    "@popperjs/core" "^2.6.0"
+    "@semantic-ui-react/event-stack" "^3.1.2"
     clsx "^1.1.1"
     keyboard-key "^1.1.0"
     lodash "^4.17.19"
     lodash-es "^4.17.15"
     prop-types "^15.7.2"
-    react-is "^16.8.6"
-    react-popper "^2.2.3"
+    react-is "^16.8.6 || ^17.0.0"
+    react-popper "^2.2.4"
     shallowequal "^1.1.0"
 
 semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewMultipleSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewMultipleSelect.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
+import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -103,7 +104,8 @@ final case class EnumViewMultipleSelect[F[_], A](
 )(implicit
   val enum:             Enumerated[A],
   val display:          Display[A],
-  val effect:           Effect[F]
+  val effect:           Effect[F],
+  val logger:           Logger[F]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewOptionalSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewOptionalSelect.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
+import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -104,7 +105,8 @@ final case class EnumViewOptionalSelect[F[_], A](
 )(implicit
   val enum:             Enumerated[A],
   val display:          Display[A],
-  val effect:           Effect[F]
+  val effect:           Effect[F],
+  val logger:           Logger[F]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewSelect.scala
@@ -12,6 +12,7 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
+import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -102,7 +103,8 @@ final case class EnumViewSelect[F[_], A](
 )(implicit
   val enum:             Enumerated[A],
   val display:          Display[A],
-  val effect:           Effect[F]
+  val effect:           Effect[F],
+  val logger:           Logger[F]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/ExternalValue.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/ExternalValue.scala
@@ -10,6 +10,7 @@ import crystal.ViewOptF
 import crystal.react.implicits._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.StateSnapshot
+import org.typelevel.log4cats.Logger
 
 trait ExternalValue[EV[_]] {
   def get[A](ev: EV[A]): Option[A]
@@ -17,7 +18,7 @@ trait ExternalValue[EV[_]] {
 }
 
 object ExternalValue {
-  implicit def externalValueViewF[F[_]: Effect]: ExternalValue[ViewF[F, *]] =
+  implicit def externalValueViewF[F[_]: Effect: Logger]: ExternalValue[ViewF[F, *]] =
     new ExternalValue[ViewF[F, *]] {
       override def get[A](ev: ViewF[F, A]): Option[A] = ev.get.some
 
@@ -25,7 +26,7 @@ object ExternalValue {
         ev.set.andThen(_.runAsyncCB)
     }
 
-  implicit def externalValueViewOptF[F[_]: Effect]: ExternalValue[ViewOptF[F, *]] =
+  implicit def externalValueViewOptF[F[_]: Effect: Logger]: ExternalValue[ViewOptF[F, *]] =
     new ExternalValue[ViewOptF[F, *]] {
       override def get[A](ev: ViewOptF[F, A]): Option[A] = ev.get
 

--- a/modules/ui/src/main/scala/lucuma/ui/utils/ReactUtils.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/utils/ReactUtils.scala
@@ -7,12 +7,13 @@ import cats.effect.Effect
 import crystal.react.implicits._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ReactMouseEvent
+import org.typelevel.log4cats.Logger
 
 trait ReactUtils {
-  def linkOverride[F[_]: Effect](f: => F[Unit]): ReactMouseEvent => Callback =
-    e => linkOverride[F, Unit](f)(Effect[F])(e, ())
+  def linkOverride[F[_]: Effect: Logger](f: => F[Unit]): ReactMouseEvent => Callback =
+    e => linkOverride[F, Unit](f)(Effect[F], Logger[F])(e, ())
 
-  def linkOverride[F[_]: Effect, A](f: => F[Unit]): (ReactMouseEvent, A) => Callback =
+  def linkOverride[F[_]: Effect: Logger, A](f: => F[Unit]): (ReactMouseEvent, A) => Callback =
     (e: ReactMouseEvent, _: A) => {
       (e.preventDefaultCB *> f.runAsyncCB)
         .unless_(e.ctrlKey || e.metaKey)


### PR DESCRIPTION
The new version of `crystal` would force us to handle errors (or log them) in effects started from Callbacks resulting from `.runAsync*CB` methods.

Opening as draft for the moment until the new `crystal` is released, so we can see how code would look like, in case anyone has ideas to improve this.