### PR TITLE
Truncated big decimals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val mouseVersion           = "1.0.2"
 lazy val reactCommonVersion     = "0.11.3"
 lazy val reactSemanticUIVersion = "0.10.6"
 lazy val kindProjectorVersion   = "0.11.3"
+lazy val singletonOpsVersion    = "0.5.0"
 
 parallelExecution in (ThisBuild, Test) := false
 
@@ -107,6 +108,7 @@ lazy val ui =
         "com.github.japgolly.scalajs-react" %%% "core"                % scalaJsReactVersion,
         "com.github.japgolly.scalajs-react" %%% "ext-monocle-cats"    % scalaJsReactVersion,
         "edu.gemini"                        %%% "lucuma-core"         % lucumaCoreVersion,
+        "eu.timepit"                        %%% "singleton-ops"       % singletonOpsVersion,
         "io.github.cquiroz.react"           %%% "common"              % reactCommonVersion,
         "io.github.cquiroz.react"           %%% "cats"                % reactCommonVersion,
         "io.github.cquiroz.react"           %%% "react-semantic-ui"   % reactSemanticUIVersion,

--- a/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
+++ b/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
@@ -29,6 +29,7 @@ import lucuma.ui.optics.ChangeAuditor
 import lucuma.ui.optics.FilterMode
 import lucuma.ui.optics.TruncatedDec
 import lucuma.ui.optics.TruncatedRA
+import lucuma.ui.optics.TruncatedRefinedBigDecimal
 import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.refined._
 import lucuma.ui.reusability._
@@ -42,11 +43,9 @@ import react.semanticui.elements.label.LabelPointing
 
 import scala.scalajs.js.annotation._
 
-object types {
-  type ZeroTo2048 = Interval.Closed[0, 2048]
-}
-final case class FormComponent(root: ViewF[IO, RootModel])(implicit val logger: Logger[IO])
-    extends ReactProps[FormComponent](FormComponent.component)
+final case class FormComponent(root: ViewF[IO, FormComponent.RootModel])(implicit
+  val logger:                        Logger[IO]
+) extends ReactProps[FormComponent](FormComponent.component)
 
 object FormComponent {
   type Props = FormComponent
@@ -60,11 +59,37 @@ object FormComponent {
     refinedInt:    Boolean = true,
     refinedOdd:    Boolean = true,
     bigDecimal:    Boolean = true,
+    refinedBigDec: Boolean = true,
     ra:            Boolean = true,
     dec:           Boolean = true,
     epoch:         Boolean = true,
     optionalEpoch: Boolean = true
   )
+
+  val OneBD   = BigDecimal(1.0)
+  val ThreeBD = BigDecimal(3.0)
+  type OneToThree = Interval.Closed[OneBD.type, ThreeBD.type]
+  type ZeroTo2048 = Interval.Closed[0, 2048]
+
+  @Lenses
+  final case class RootModel(
+    field1:        UpperNES,
+    field2:        String,
+    forcedUpper:   String Refined UpperNEPred,
+    justAnInt:     Int,
+    refinedInt:    Int Refined Interval.Closed[0, 2048],
+    refinedOdd:    Int Refined Odd,
+    bigDecimal:    BigDecimal,
+    refinedBigDec: BigDecimal Refined OneToThree,
+    ra:            RightAscension,
+    dec:           Declination,
+    epoch:         Epoch,
+    optionalEpoch: Option[Epoch]
+  )
+
+  object RootModel {
+    implicit val modelReusability: Reusability[RootModel] = Reusability.by_==[RootModel]
+  }
 
   implicit val propsReuse = Reusability.derive[Props]
   implicit val stateReuse = Reusability.derive[State]
@@ -136,9 +161,8 @@ object FormComponent {
               value = $.props.root.zoom(RootModel.refinedInt),
               errorClazz = Css("error-label"),
               errorPointing = LabelPointing.Below,
-              validFormat =
-                ValidFormatInput.forRefinedInt[types.ZeroTo2048]("Must be in range 0-2048"),
-              changeAuditor = ChangeAuditor.forRefinedInt[types.ZeroTo2048](),
+              validFormat = ValidFormatInput.forRefinedInt[ZeroTo2048]("Must be in range 0-2048"),
+              changeAuditor = ChangeAuditor.forRefinedInt[ZeroTo2048](),
               onValidChange = v => $.setStateL(State.refinedInt)(v)
             ),
             FormInputEV(
@@ -160,6 +184,21 @@ object FormComponent {
               validFormat = ValidFormatInput.bigDecimalValidFormat(),
               changeAuditor = ChangeAuditor.bigDecimal(4),
               onValidChange = v => $.setStateL(State.bigDecimal)(v)
+            ),
+            FormInputEV(
+              id = "refined-big-decimal",
+              label = "Refined Big Decimal - 1 decimal place",
+              value = $.props.root
+                .zoom(RootModel.refinedBigDec)
+                .zoomSplitEpi(
+                  TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree](1)
+                ),
+              errorClazz = Css("error-label"),
+              errorPointing = LabelPointing.Below,
+              validFormat = ValidFormatInput
+                .forRefinedTruncatedBigDecimal[OneToThree](1, "Must be 1.0 to 3.0"),
+              changeAuditor = ChangeAuditor.accept.decimal(1),
+              onValidChange = v => $.setStateL(State.refinedBigDec)(v)
             ),
             FormInputEV(
               id = "ra",
@@ -211,25 +250,6 @@ object FormComponent {
       .build
 }
 
-@Lenses
-final case class RootModel(
-  field1:        UpperNES,
-  field2:        String,
-  forcedUpper:   String Refined UpperNEPred,
-  justAnInt:     Int,
-  refinedInt:    Int Refined Interval.Closed[0, 2048],
-  refinedOdd:    Int Refined Odd,
-  bigDecimal:    BigDecimal,
-  ra:            RightAscension,
-  dec:           Declination,
-  epoch:         Epoch,
-  optionalEpoch: Option[Epoch]
-)
-
-object RootModel {
-  implicit val modelReusability: Reusability[RootModel] = Reusability.by_==[RootModel]
-}
-
 case class AppContext[F[_]]()(implicit val cs: ContextShift[F])
 
 object AppContext {
@@ -239,6 +259,7 @@ object AppContext {
 object AppCtx extends Ctx[IO, AppContext[IO]]
 
 trait AppMain extends IOApp {
+  import FormComponent._
 
   implicit protected val logger: Logger[IO] = LogLevelLogger.createForRoot[IO]
 
@@ -260,7 +281,8 @@ trait AppMain extends IOApp {
         0,
         0,
         1,
-        0.1234,
+        0.123456,
+        Refined.unsafeApply[BigDecimal, OneToThree](OneBD),
         RightAscension.fromStringHMS.getOption("12:34:56.789876").get,
         Declination.fromStringSignedDMS.getOption("-11:22:33.987654").get,
         Epoch.J2000,
@@ -288,6 +310,6 @@ trait AppMain extends IOApp {
 
 @JSExportTopLevel("Demo")
 object Demo extends AppMain {
-  override protected def rootComponent(rootView: ViewF[IO, RootModel]): VdomElement =
+  override protected def rootComponent(rootView: ViewF[IO, FormComponent.RootModel]): VdomElement =
     FormComponent(rootView)
 }

--- a/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
+++ b/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
@@ -191,12 +191,12 @@ object FormComponent {
               value = $.props.root
                 .zoom(RootModel.refinedBigDec)
                 .zoomSplitEpi(
-                  TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree](1)
+                  TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree, 1]
                 ),
               errorClazz = Css("error-label"),
               errorPointing = LabelPointing.Below,
               validFormat = ValidFormatInput
-                .forRefinedTruncatedBigDecimal[OneToThree](1, "Must be 1.0 to 3.0"),
+                .forRefinedTruncatedBigDecimal[OneToThree, 1]("Must be 1.0 to 3.0"),
               changeAuditor = ChangeAuditor.accept.decimal(1),
               onValidChange = v => $.setStateL(State.refinedBigDec)(v)
             ),

--- a/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedBigDecimal.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedBigDecimal.scala
@@ -5,34 +5,40 @@ package lucuma.ui.optics
 
 import cats.Eq
 import lucuma.core.optics.SplitEpi
+import scala.annotation.unused
+import singleton.ops._
 
 /**
  * A wrapper around a BigDecimal that is limited to a specified
  * number of decimals places.
  *
- * The Dec type parameter must be a Singleton Int, which is enforced
- *    by the compiler. The compiler cannot, however, keep you from
- *    specifying negative numbers or extreme values. So, don't.
+ * The Dec type parameter must be a Singleton Int > 0 and < 10, which is enforced
+ *    by the compiler.
  *
  * @param value The BigDecimal. It is guaranteed to have a scale of no more than Dec.
+ * @param req Requirement that 0 < Dec < 10
  * @param vo Evidence that Dec is a Singleton type.
  */
-sealed abstract case class TruncatedBigDecimal[Dec <: Int] private (value: BigDecimal)(implicit
-  vo:                                                                      ValueOf[Dec]
+sealed abstract case class TruncatedBigDecimal[Dec <: XInt] private (value: BigDecimal)(implicit
+  @unused req:                                                              Require[&&[Dec > 0, Dec < 10]],
+  vo:                                                                       ValueOf[Dec]
 ) { val decimals: Int = vo.value }
 
 object TruncatedBigDecimal {
 
-  def apply[Dec <: Int](value: BigDecimal)(implicit vo: ValueOf[Dec]): TruncatedBigDecimal[Dec] =
+  def apply[Dec <: XInt](
+    value:        BigDecimal
+  )(implicit req: Require[&&[Dec > 0, Dec < 10]], vo: ValueOf[Dec]): TruncatedBigDecimal[Dec] =
     new TruncatedBigDecimal[Dec](
       value.setScale(vo.value, BigDecimal.RoundingMode.HALF_UP)
     ) {}
 
-  def bigDecimal[Dec <: Int](implicit
-    vo:                        ValueOf[Dec]
+  def bigDecimal[Dec <: XInt](implicit
+    req:          Require[&&[Dec > 0, Dec < 10]],
+    vo:           ValueOf[Dec]
   ): SplitEpi[BigDecimal, TruncatedBigDecimal[Dec]] =
     SplitEpi(TruncatedBigDecimal(_), _.value)
 
-  implicit def truncatedBigDecimalEq[Dec <: Int]: Eq[TruncatedBigDecimal[Dec]] =
+  implicit def truncatedBigDecimalEq[Dec <: XInt]: Eq[TruncatedBigDecimal[Dec]] =
     Eq.by(_.value)
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedBigDecimal.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedBigDecimal.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import cats.Eq
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Interval
+import lucuma.core.optics.SplitEpi
+
+sealed abstract case class TruncatedBigDecimal private (value: BigDecimal)
+
+object TruncatedBigDecimal {
+  type Decimals    = Interval.Closed[1, 10]
+  type IntDecimals = Int Refined Decimals
+
+  def apply(value:         BigDecimal, decimals: IntDecimals): TruncatedBigDecimal =
+    new TruncatedBigDecimal(
+      value.setScale(decimals.value, BigDecimal.RoundingMode.FLOOR)
+    ) {}
+
+  def bigDecimal(decimals: IntDecimals): SplitEpi[BigDecimal, TruncatedBigDecimal] =
+    SplitEpi(TruncatedBigDecimal(_, decimals), _.value)
+
+  implicit val truncatedBigDecimalEq: Eq[TruncatedBigDecimal] =
+    Eq.by(_.value)
+}

--- a/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import cats.Order
+import eu.timepit.refined.refineV
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.{ Validate => RefinedValidate }
+import eu.timepit.refined.cats._
+import eu.timepit.refined.numeric.Interval
+import lucuma.core.optics.SplitEpi
+
+sealed abstract case class TruncatedRefinedBigDecimal[P] private (
+  value: BigDecimal Refined P
+)
+
+object TruncatedRefinedBigDecimal {
+  type Decimals    = Interval.Closed[1, 10]
+  type IntDecimals = Int Refined Decimals
+
+  def apply[P](value: BigDecimal Refined P, decimals: IntDecimals)(implicit
+    v:                RefinedValidate[BigDecimal, P]
+  ): Option[TruncatedRefinedBigDecimal[P]] = {
+    val truncBD = value.value.setScale(decimals.value, BigDecimal.RoundingMode.HALF_UP)
+    refineV[P](truncBD).toOption.map(v => new TruncatedRefinedBigDecimal[P](v) {})
+  }
+
+  def unsafeRefinedBigDecimal[P](
+    decimals: IntDecimals
+  )(implicit
+    v:        RefinedValidate[BigDecimal, P]
+  ): SplitEpi[BigDecimal Refined P, TruncatedRefinedBigDecimal[P]] =
+    SplitEpi(TruncatedRefinedBigDecimal[P](_, decimals).get, _.value)
+
+  implicit def truncatedRefinedBigDecimalOrder[P]: Order[TruncatedRefinedBigDecimal[P]] =
+    Order.by(_.value)
+}

--- a/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
@@ -9,30 +9,33 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.{ Validate => RefinedValidate }
 import eu.timepit.refined.cats._
 import lucuma.core.optics.SplitEpi
+import scala.annotation.unused
+import singleton.ops._
 
 /**
  * A wrapper around a Refined BigDecimal that is limited to a specified
  * number of decimals places.
  *
  * The P type parameter is the refinement.
- * The Dec type parameter must be a Singleton Int, which is enforced
- *    by the compiler. The compiler cannot, however, keep you from
- *    specifying negative numbers or extreme values. So, don't.
+ * The Dec type parameter must be a Singleton Int > 0 and < 10, which is enforced
+ *    by the compiler.
  *
  * @param value The refined BigDecimal. It is guaranteed to have a scale of no more than Dec.
+ * @param req Requirement that 0 < Dec < 10
  * @param vo Evidence that Dec is a Singleton type.
  */
-sealed abstract case class TruncatedRefinedBigDecimal[P, Dec <: Int] private (
-  value:       BigDecimal Refined P
-)(implicit vo: ValueOf[Dec]) {
-  val decimals: Int = vo.value
+sealed abstract case class TruncatedRefinedBigDecimal[P, Dec <: XInt] private (
+  value:                BigDecimal Refined P
+)(implicit @unused req: Require[&&[Dec > 0, Dec < 10]], vo: ValueOf[Dec]) {
+  val decimals: XInt = vo.value
 }
 
 object TruncatedRefinedBigDecimal {
 
-  def apply[P, Dec <: Int](value: BigDecimal Refined P)(implicit
-    v:                            RefinedValidate[BigDecimal, P],
-    vo:                           ValueOf[Dec]
+  def apply[P, Dec <: XInt](value: BigDecimal Refined P)(implicit
+    v:                             RefinedValidate[BigDecimal, P],
+    req:                           Require[&&[Dec > 0, Dec < 10]],
+    vo:                            ValueOf[Dec]
   ): Option[TruncatedRefinedBigDecimal[P, Dec]] = {
     val truncBD = value.value.setScale(vo.value, BigDecimal.RoundingMode.HALF_UP)
     refineV[P](truncBD).toOption.map(v => new TruncatedRefinedBigDecimal[P, Dec](v) {})
@@ -41,7 +44,7 @@ object TruncatedRefinedBigDecimal {
   /**
    * Gets a SplitEpi for the TruncatedRefinedBigDecimal.
    *
-   * This is unsave under some occassions. For instance, say P is
+   * This is unsafe under some occassions. For instance, say P is
    * Interval.Closed[1.23, 7.28] and 1 decimal place is specified
    * via Dec. If the input value to get() is 1.23, it will get rounded
    * down to 1.2, which is invalid and an exception is thrown. Since
@@ -56,13 +59,14 @@ object TruncatedRefinedBigDecimal {
    * Non Interval refinements can also be problematic, so use this with
    * caution.
    */
-  def unsafeRefinedBigDecimal[P, Dec <: Int](implicit
-    v:  RefinedValidate[BigDecimal, P],
-    vo: ValueOf[Dec]
+  def unsafeRefinedBigDecimal[P, Dec <: XInt](implicit
+    v:           RefinedValidate[BigDecimal, P],
+    @unused req: Require[&&[Dec > 0, Dec < 10]],
+    vo:          ValueOf[Dec]
   ): SplitEpi[BigDecimal Refined P, TruncatedRefinedBigDecimal[P, Dec]] =
     SplitEpi(TruncatedRefinedBigDecimal[P, Dec](_).get, _.value)
 
-  implicit def truncatedRefinedBigDecimalOrder[P, Dec <: Int]
+  implicit def truncatedRefinedBigDecimalOrder[P, Dec <: XInt]
     : Order[TruncatedRefinedBigDecimal[P, Dec]] =
     Order.by(_.value)
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/TruncatedRefinedBigDecimal.scala
@@ -8,31 +8,61 @@ import eu.timepit.refined.refineV
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.{ Validate => RefinedValidate }
 import eu.timepit.refined.cats._
-import eu.timepit.refined.numeric.Interval
 import lucuma.core.optics.SplitEpi
 
-sealed abstract case class TruncatedRefinedBigDecimal[P] private (
-  value: BigDecimal Refined P
-)
+/**
+ * A wrapper around a Refined BigDecimal that is limited to a specified
+ * number of decimals places.
+ *
+ * The P type parameter is the refinement.
+ * The Dec type parameter must be a Singleton Int, which is enforced
+ *    by the compiler. The compiler cannot, however, keep you from
+ *    specifying negative numbers or extreme values. So, don't.
+ *
+ * @param value The refined BigDecimal. It is guaranteed to have a scale of no more than Dec.
+ * @param vo Evidence that Dec is a Singleton type.
+ */
+sealed abstract case class TruncatedRefinedBigDecimal[P, Dec <: Int] private (
+  value:       BigDecimal Refined P
+)(implicit vo: ValueOf[Dec]) {
+  val decimals: Int = vo.value
+}
 
 object TruncatedRefinedBigDecimal {
-  type Decimals    = Interval.Closed[1, 10]
-  type IntDecimals = Int Refined Decimals
 
-  def apply[P](value: BigDecimal Refined P, decimals: IntDecimals)(implicit
-    v:                RefinedValidate[BigDecimal, P]
-  ): Option[TruncatedRefinedBigDecimal[P]] = {
-    val truncBD = value.value.setScale(decimals.value, BigDecimal.RoundingMode.HALF_UP)
-    refineV[P](truncBD).toOption.map(v => new TruncatedRefinedBigDecimal[P](v) {})
+  def apply[P, Dec <: Int](value: BigDecimal Refined P)(implicit
+    v:                            RefinedValidate[BigDecimal, P],
+    vo:                           ValueOf[Dec]
+  ): Option[TruncatedRefinedBigDecimal[P, Dec]] = {
+    val truncBD = value.value.setScale(vo.value, BigDecimal.RoundingMode.HALF_UP)
+    refineV[P](truncBD).toOption.map(v => new TruncatedRefinedBigDecimal[P, Dec](v) {})
   }
 
-  def unsafeRefinedBigDecimal[P](
-    decimals: IntDecimals
-  )(implicit
-    v:        RefinedValidate[BigDecimal, P]
-  ): SplitEpi[BigDecimal Refined P, TruncatedRefinedBigDecimal[P]] =
-    SplitEpi(TruncatedRefinedBigDecimal[P](_, decimals).get, _.value)
+  /**
+   * Gets a SplitEpi for the TruncatedRefinedBigDecimal.
+   *
+   * This is unsave under some occassions. For instance, say P is
+   * Interval.Closed[1.23, 7.28] and 1 decimal place is specified
+   * via Dec. If the input value to get() is 1.23, it will get rounded
+   * down to 1.2, which is invalid and an exception is thrown. Since
+   * we are rounding up, an imput value of 7.28 will be rounded up
+   * to 7.3, which is also invalid (using FLOOR would be safe for the
+   * upper bound, but not the lower bound.).
+   *
+   * In general, you have to specify at least as many decimals for the
+   * rounding as the scale implicitly specified in the Interval bounds.
+   * For this example, Dec would need to be set to at least 2.
+   *
+   * Non Interval refinements can also be problematic, so use this with
+   * caution.
+   */
+  def unsafeRefinedBigDecimal[P, Dec <: Int](implicit
+    v:  RefinedValidate[BigDecimal, P],
+    vo: ValueOf[Dec]
+  ): SplitEpi[BigDecimal Refined P, TruncatedRefinedBigDecimal[P, Dec]] =
+    SplitEpi(TruncatedRefinedBigDecimal[P, Dec](_).get, _.value)
 
-  implicit def truncatedRefinedBigDecimalOrder[P]: Order[TruncatedRefinedBigDecimal[P]] =
+  implicit def truncatedRefinedBigDecimalOrder[P, Dec <: Int]
+    : Order[TruncatedRefinedBigDecimal[P, Dec]] =
     Order.by(_.value)
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
@@ -101,18 +101,20 @@ object ValidFormatInput extends ValidFormatInputInstances {
       ValidFormat.forRefined[NonEmptyChain[NonEmptyString], BigDecimal, P](NonEmptyChain(error))
     )
 
-  def forRefinedTruncatedBigDecimal[P](
-    decimals:   TruncatedRefinedBigDecimal.IntDecimals,
-    error:      NonEmptyString = "Invalid format"
-  )(implicit v: RefinedValidate[BigDecimal, P]): ValidFormatInput[TruncatedRefinedBigDecimal[P]] = {
+  def forRefinedTruncatedBigDecimal[P, Dec <: Int](
+    error: NonEmptyString = "Invalid format"
+  )(implicit
+    v:     RefinedValidate[BigDecimal, P],
+    vo:    ValueOf[Dec]
+  ): ValidFormatInput[TruncatedRefinedBigDecimal[P, Dec]] = {
     val prism = ValidFormat.refinedPrism[BigDecimal, P]
-    ValidFormatInput[TruncatedRefinedBigDecimal[P]](
+    ValidFormatInput[TruncatedRefinedBigDecimal[P, Dec]](
       s =>
         fixDecimalString(s).parseBigDecimalOption
           .flatMap(prism.getOption(_))
-          .flatMap(TruncatedRefinedBigDecimal.apply[P](_, decimals))
-          .fold(error.invalidNec[TruncatedRefinedBigDecimal[P]])(_.validNec),
-      trbd => s"%.${decimals.value}f".format(trbd.value.value)
+          .flatMap(TruncatedRefinedBigDecimal.apply[P, Dec](_))
+          .fold(error.invalidNec[TruncatedRefinedBigDecimal[P, Dec]])(_.validNec),
+      trbd => s"%.${vo.value}f".format(trbd.value.value)
     )
   }
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInput.scala
@@ -15,6 +15,7 @@ import lucuma.core.optics.Format
 import monocle.Iso
 import monocle.Prism
 import mouse.all._
+import singleton.ops._
 
 /**
  * Convenience version of `ValidFormat` when the error type is `NonEmptyChain[String]` and `T = String`.
@@ -101,10 +102,11 @@ object ValidFormatInput extends ValidFormatInputInstances {
       ValidFormat.forRefined[NonEmptyChain[NonEmptyString], BigDecimal, P](NonEmptyChain(error))
     )
 
-  def forRefinedTruncatedBigDecimal[P, Dec <: Int](
+  def forRefinedTruncatedBigDecimal[P, Dec <: XInt](
     error: NonEmptyString = "Invalid format"
   )(implicit
     v:     RefinedValidate[BigDecimal, P],
+    req:   Require[&&[Dec > 0, Dec < 10]],
     vo:    ValueOf[Dec]
   ): ValidFormatInput[TruncatedRefinedBigDecimal[P, Dec]] = {
     val prism = ValidFormat.refinedPrism[BigDecimal, P]

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
@@ -12,6 +12,7 @@ import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
 import lucuma.ui.refined._
 import mouse.all._
+import singleton.ops._
 
 /**
  * Convenience ValidFormatInput instances.
@@ -45,9 +46,9 @@ trait ValidFormatInputInstances {
       _.toString
     )
 
-  def truncatedBigDecimalValidFormat[Dec <: Int](
+  def truncatedBigDecimalValidFormat[Dec <: XInt](
     errorMessage: NonEmptyString = "Must be a number"
-  )(implicit vo:  ValueOf[Dec]) =
+  )(implicit req: Require[&&[Dec > 0, Dec < 10]], vo: ValueOf[Dec]) =
     ValidFormatInput[TruncatedBigDecimal[Dec]](
       s =>
         fixDecimalString(s).parseBigDecimalOption

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
@@ -45,17 +45,16 @@ trait ValidFormatInputInstances {
       _.toString
     )
 
-  def truncatedBigDecimalValidFormat(
-    decimals:     TruncatedBigDecimal.IntDecimals,
+  def truncatedBigDecimalValidFormat[Dec <: Int](
     errorMessage: NonEmptyString = "Must be a number"
-  ) =
-    ValidFormatInput[TruncatedBigDecimal](
+  )(implicit vo:  ValueOf[Dec]) =
+    ValidFormatInput[TruncatedBigDecimal[Dec]](
       s =>
         fixDecimalString(s).parseBigDecimalOption
-          .fold(errorMessage.invalidNec[TruncatedBigDecimal])(
-            TruncatedBigDecimal(_, decimals).validNec
+          .fold(errorMessage.invalidNec[TruncatedBigDecimal[Dec]])(
+            TruncatedBigDecimal[Dec](_).validNec
           ),
-      tbd => s"%.${decimals.value}f".format(tbd.value)
+      tbd => s"%.${vo.value}f".format(tbd.value)
     )
 
   val truncatedRA = ValidFormatInput[TruncatedRA](

--- a/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedBigDecimalSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedBigDecimalSpec.scala
@@ -4,7 +4,6 @@
 package lucuma.ui.optics
 
 import cats.kernel.laws.discipline.EqTests
-import eu.timepit.refined.auto._
 import lucuma.core.optics.laws.discipline.SplitEpiTests
 import lucuma.ui.optics.arb._
 import org.scalacheck.Arbitrary._
@@ -13,9 +12,9 @@ import munit.DisciplineSuite
 class TruncatedBigDecimalSpec extends DisciplineSuite {
   import ArbTruncatedBigDecimal._
 
-  checkAll("TruncatedBigDecimal", EqTests[TruncatedBigDecimal].eqv)
+  checkAll("TruncatedBigDecimal", EqTests[TruncatedBigDecimal[2]].eqv)
 
   checkAll("TruncatedRefinedBigDecimal.bigDecimal",
-           SplitEpiTests(TruncatedBigDecimal.bigDecimal(2)).splitEpi
+           SplitEpiTests(TruncatedBigDecimal.bigDecimal[2]).splitEpi
   )
 }

--- a/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedBigDecimalSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedBigDecimalSpec.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import cats.kernel.laws.discipline.EqTests
+import eu.timepit.refined.auto._
+import lucuma.core.optics.laws.discipline.SplitEpiTests
+import lucuma.ui.optics.arb._
+import org.scalacheck.Arbitrary._
+import munit.DisciplineSuite
+
+class TruncatedBigDecimalSpec extends DisciplineSuite {
+  import ArbTruncatedBigDecimal._
+
+  checkAll("TruncatedBigDecimal", EqTests[TruncatedBigDecimal].eqv)
+
+  checkAll("TruncatedRefinedBigDecimal.bigDecimal",
+           SplitEpiTests(TruncatedBigDecimal.bigDecimal(2)).splitEpi
+  )
+}

--- a/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedRefinedBigDecimalSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedRefinedBigDecimalSpec.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import cats.kernel.laws.discipline.OrderTests
+import eu.timepit.refined.auto._
+import eu.timepit.refined.cats._
+import lucuma.core.optics.laws.discipline.SplitEpiTests
+import lucuma.ui.optics.arb._
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary._
+
+class TruncatedRefinedBigDecimalSpec extends DisciplineSuite {
+  import ArbTruncatedRefinedBigDecimal._
+
+  checkAll("TruncatedRefinedBigDecimal", OrderTests[TruncatedRefinedBigDecimal[OneToThree]].order)
+
+  checkAll("TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal",
+           SplitEpiTests(TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree](1)).splitEpi
+  )
+}

--- a/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedRefinedBigDecimalSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/TruncatedRefinedBigDecimalSpec.scala
@@ -4,7 +4,6 @@
 package lucuma.ui.optics
 
 import cats.kernel.laws.discipline.OrderTests
-import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import lucuma.core.optics.laws.discipline.SplitEpiTests
 import lucuma.ui.optics.arb._
@@ -14,9 +13,11 @@ import org.scalacheck.Arbitrary._
 class TruncatedRefinedBigDecimalSpec extends DisciplineSuite {
   import ArbTruncatedRefinedBigDecimal._
 
-  checkAll("TruncatedRefinedBigDecimal", OrderTests[TruncatedRefinedBigDecimal[OneToThree]].order)
+  checkAll("TruncatedRefinedBigDecimal",
+           OrderTests[TruncatedRefinedBigDecimal[OneToThree, 1]].order
+  )
 
   checkAll("TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal",
-           SplitEpiTests(TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree](1)).splitEpi
+           SplitEpiTests(TruncatedRefinedBigDecimal.unsafeRefinedBigDecimal[OneToThree, 1]).splitEpi
   )
 }

--- a/modules/ui/src/test/scala/lucuma/ui/optics/ValidFormatInputInstancesSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/ValidFormatInputInstancesSpec.scala
@@ -43,11 +43,11 @@ final class ValidFormatInputInstancesSpec extends DisciplineSuite {
            ValidFormatTests(ValidFormatInput.bigDecimalValidFormat()).validFormat
   )
   checkAll("truncatedBigDecimalValidFormat",
-           ValidFormatTests(ValidFormatInput.truncatedBigDecimalValidFormat(2)).validFormat
+           ValidFormatTests(ValidFormatInput.truncatedBigDecimalValidFormat[2]()).validFormat
   )
   checkAll(
     "forTruncatedRefinedBigDecimal",
-    ValidFormatTests(ValidFormatInput.forRefinedTruncatedBigDecimal[OneToThree](1)).validFormat
+    ValidFormatTests(ValidFormatInput.forRefinedTruncatedBigDecimal[OneToThree, 1]()).validFormat
   )
   checkAll("truncatedRAValidFormat", ValidFormatTests(ValidFormatInput.truncatedRA).validFormat)
   checkAll("truncatedDecValidFormat", ValidFormatTests(ValidFormatInput.truncatedDec).validFormat)

--- a/modules/ui/src/test/scala/lucuma/ui/optics/ValidFormatInputInstancesSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/ValidFormatInputInstancesSpec.scala
@@ -11,12 +11,15 @@ import lucuma.ui.optics.arb._
 import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.optics.laws.discipline.ValidFormatTests
 import lucuma.ui.refined._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.scalacheck.all._
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary
 
 final class ValidFormatInputInstancesSpec extends DisciplineSuite {
+  import ArbTruncatedBigDecimal._
+  import ArbTruncatedRefinedBigDecimal._
   import ArbTruncatedRA._
   import ArbTruncatedDec._
 
@@ -38,6 +41,13 @@ final class ValidFormatInputInstancesSpec extends DisciplineSuite {
   checkAll("intValidFormat", ValidFormatTests(ValidFormatInput.intValidFormat()).validFormat)
   checkAll("bigDecimalValidFormat",
            ValidFormatTests(ValidFormatInput.bigDecimalValidFormat()).validFormat
+  )
+  checkAll("truncatedBigDecimalValidFormat",
+           ValidFormatTests(ValidFormatInput.truncatedBigDecimalValidFormat(2)).validFormat
+  )
+  checkAll(
+    "forTruncatedRefinedBigDecimal",
+    ValidFormatTests(ValidFormatInput.forRefinedTruncatedBigDecimal[OneToThree](1)).validFormat
   )
   checkAll("truncatedRAValidFormat", ValidFormatTests(ValidFormatInput.truncatedRA).validFormat)
   checkAll("truncatedDecValidFormat", ValidFormatTests(ValidFormatInput.truncatedDec).validFormat)

--- a/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedBigDecimal.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedBigDecimal.scala
@@ -3,22 +3,17 @@
 
 package lucuma.ui.optics.arb
 
-import eu.timepit.refined.auto._
-import eu.timepit.refined.scalacheck.numeric.intervalClosedArbitrary
 import lucuma.ui.optics.TruncatedBigDecimal
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
 trait ArbTruncatedBigDecimal {
 
-  implicit val arbClosedInterval: Arbitrary[TruncatedBigDecimal.IntDecimals] =
-    intervalClosedArbitrary
-
-  implicit val arbTruncatedDecimal = Arbitrary[TruncatedBigDecimal] {
-    arbitrary[BigDecimal].map(TruncatedBigDecimal(_, 2))
+  implicit val arbTruncatedDecimal = Arbitrary[TruncatedBigDecimal[2]] {
+    arbitrary[BigDecimal].map(TruncatedBigDecimal[2](_))
   }
 
-  implicit def cogTruncatedBigDecimal: Cogen[TruncatedBigDecimal] =
+  implicit def cogTruncatedBigDecimal: Cogen[TruncatedBigDecimal[2]] =
     Cogen[BigDecimal].contramap(_.value)
 }
 

--- a/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedBigDecimal.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedBigDecimal.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics.arb
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.scalacheck.numeric.intervalClosedArbitrary
+import lucuma.ui.optics.TruncatedBigDecimal
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbTruncatedBigDecimal {
+
+  implicit val arbClosedInterval: Arbitrary[TruncatedBigDecimal.IntDecimals] =
+    intervalClosedArbitrary
+
+  implicit val arbTruncatedDecimal = Arbitrary[TruncatedBigDecimal] {
+    arbitrary[BigDecimal].map(TruncatedBigDecimal(_, 2))
+  }
+
+  implicit def cogTruncatedBigDecimal: Cogen[TruncatedBigDecimal] =
+    Cogen[BigDecimal].contramap(_.value)
+}
+
+object ArbTruncatedBigDecimal extends ArbTruncatedBigDecimal

--- a/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
@@ -25,7 +25,6 @@ trait ArbTruncatedRefinedBigDecimal {
 
   implicit def cogTruncRefinedBD: Cogen[TruncatedRefinedBigDecimal[OneToThree, 1]] =
     Cogen[BigOneToThree].contramap(trbd => trbd.value)
-  // Cogen[(BigOneToThree, Int)].contramap(trbd => (trbd.value, trbd.decimals))
 }
 
 object ArbTruncatedRefinedBigDecimal extends ArbTruncatedRefinedBigDecimal

--- a/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
@@ -4,7 +4,6 @@
 package lucuma.ui.optics.arb
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
 import eu.timepit.refined.scalacheck._
 import eu.timepit.refined.scalacheck.numeric.intervalClosedArbitrary
 import eu.timepit.refined.numeric.Interval
@@ -20,11 +19,11 @@ trait ArbTruncatedRefinedBigDecimal {
 
   implicit val arbClosed: Arbitrary[BigOneToThree] = intervalClosedArbitrary
 
-  implicit val arbTruncRefinedBD = Arbitrary[TruncatedRefinedBigDecimal[OneToThree]] {
-    arbitrary[BigOneToThree].map(TruncatedRefinedBigDecimal[OneToThree](_, 1).get)
+  implicit val arbTruncRefinedBD = Arbitrary[TruncatedRefinedBigDecimal[OneToThree, 1]] {
+    arbitrary[BigOneToThree].map(TruncatedRefinedBigDecimal[OneToThree, 1](_).get)
   }
 
-  implicit def cogTruncRefinedBD: Cogen[TruncatedRefinedBigDecimal[OneToThree]] =
+  implicit def cogTruncRefinedBD: Cogen[TruncatedRefinedBigDecimal[OneToThree, 1]] =
     Cogen[BigOneToThree].contramap(trbd => trbd.value)
   // Cogen[(BigOneToThree, Int)].contramap(trbd => (trbd.value, trbd.decimals))
 }

--- a/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/arb/ArbTruncatedRefinedBigDecimal.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics.arb
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.scalacheck._
+import eu.timepit.refined.scalacheck.numeric.intervalClosedArbitrary
+import eu.timepit.refined.numeric.Interval
+import lucuma.ui.optics.TruncatedRefinedBigDecimal
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+trait ArbTruncatedRefinedBigDecimal {
+  val OneBD   = BigDecimal(1.0)
+  val ThreeBD = BigDecimal(3.0)
+  type OneToThree    = Interval.Closed[OneBD.type, ThreeBD.type]
+  type BigOneToThree = BigDecimal Refined OneToThree
+
+  implicit val arbClosed: Arbitrary[BigOneToThree] = intervalClosedArbitrary
+
+  implicit val arbTruncRefinedBD = Arbitrary[TruncatedRefinedBigDecimal[OneToThree]] {
+    arbitrary[BigOneToThree].map(TruncatedRefinedBigDecimal[OneToThree](_, 1).get)
+  }
+
+  implicit def cogTruncRefinedBD: Cogen[TruncatedRefinedBigDecimal[OneToThree]] =
+    Cogen[BigOneToThree].contramap(trbd => trbd.value)
+  // Cogen[(BigOneToThree, Int)].contramap(trbd => (trbd.value, trbd.decimals))
+}
+
+object ArbTruncatedRefinedBigDecimal extends ArbTruncatedRefinedBigDecimal


### PR DESCRIPTION
This PR provides the ability to truncate BigDecimals and Refined Big Decimals in the UI. 

Refined BigDecimals introduces the possibilty of an invalid value when rounding. See the comment in TruncatedRefinedBigDecimal.scala for details. It was impossible to make this entirely safe to use. Maybe one of y'all will have some better ideas.

The first commit of the PR has the number of decimal places as a regular, but refined, parameter. This has the advantage that, for Refined BigDecimals, the type of the refinement can sometimes be inferred. And, it is also impossible to specify outrageous values for the number of decimals.

The second commit moves the number of decimal places to a Singleton Int type parameter. This has the advantage that Truncated*BigDecimals with different numbers of decimals are different types. This introduces some safety that the number of decimals line up. However, it also requires that the refinement type must always be specified, which introduces more verbosity. It also can't prevent the specification of negative numbers of decimals or outrageously large ones.

