### PR TITLE
EnumViewSelects no longer require Logger.

### DIFF
--- a/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
+++ b/modules/demo/src/main/scala/lucuma/ui/demo/Demo.scala
@@ -20,7 +20,6 @@ import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.ReusabilityOverlay
 import japgolly.scalajs.react.vdom.html_<^._
-import log4cats.loglevel.LogLevelLogger
 import lucuma.core.math.Declination
 import lucuma.core.math.Epoch
 import lucuma.core.math.RightAscension
@@ -36,7 +35,6 @@ import lucuma.ui.refined._
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import org.scalajs.dom
-import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common.style.Css
 import react.semanticui.collections.form.Form
@@ -250,8 +248,6 @@ object FormComponent {
 
 trait AppMain extends IOApp.Simple {
   import FormComponent._
-
-  implicit protected val logger: Logger[IO] = LogLevelLogger.createForRoot[IO]
 
   protected def rootComponent(view: ViewF[SyncIO, RootModel]): VdomElement
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewMultipleSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewMultipleSelect.scala
@@ -11,7 +11,6 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
-import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -103,8 +102,7 @@ final case class EnumViewMultipleSelect[A](
   modifiers:            Seq[TagMod] = Seq.empty
 )(implicit
   val enum:             Enumerated[A],
-  val display:          Display[A],
-  val logger:           Logger[SyncIO]
+  val display:          Display[A]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewOptionalSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewOptionalSelect.scala
@@ -12,7 +12,6 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
-import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -105,8 +104,7 @@ final case class EnumViewOptionalSelect[A](
   modifiers:            Seq[TagMod] = Seq.empty
 )(implicit
   val enum:             Enumerated[A],
-  val display:          Display[A],
-  val logger:           Logger[SyncIO]
+  val display:          Display[A]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumViewSelect.scala
@@ -13,7 +13,6 @@ import japgolly.scalajs.react.raw.JsNumber
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
-import org.typelevel.log4cats.Logger
 import react.common.ReactProps
 import react.common._
 import react.semanticui._
@@ -103,8 +102,7 @@ final case class EnumViewSelect[A](
   modifiers:            Seq[TagMod] = Seq.empty
 )(implicit
   val enum:             Enumerated[A],
-  val display:          Display[A],
-  val logger:           Logger[SyncIO]
+  val display:          Display[A]
 ) extends ReactProps[EnumViewSelectBase](EnumViewSelectBase.component)
     with EnumViewSelectBase {
 


### PR DESCRIPTION
`crystal` requires a `Logger` when triggering async effects, so that it can inform in case of errors.

However, now that we switched to sync effects in `EnumViewSelect`s, errors will be thrown and so the `Logger` is no longer used, but it was still present in the API.