### PR TITLE
Proper reusability for EnumSelect.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.26"
+ThisBuild / tlBaseVersion       := "0.27"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"


### PR DESCRIPTION
This allows us to define reusability externally, instead of depending just on the display value of the enum.

There are use cases where we want to change the `onClick` callback without changing the value, but it wouldn't be possible since `onClick` was not part of reusability.