### PR TITLE
Formats and Auditors.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val reactJS = "17.0.2"
 lazy val FUILess = "2.8.7"
 
 lazy val scalaJsReactVersion    = "2.0.1"
-lazy val lucumaCoreVersion      = "0.25.0"
+lazy val lucumaCoreVersion      = "0.26.0"
 lazy val monocleVersion         = "3.1.0"
 lazy val crystalVersion         = "0.21.4"
 lazy val catsVersion            = "2.7.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.27"
+ThisBuild / tlBaseVersion       := "0.28"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/scala/lucuma/ui/forms/EnumSelect.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/forms/EnumSelect.scala
@@ -19,8 +19,8 @@ import scala.scalajs.js.JSConverters._
  * Produces a dropdown menu, similar to a combobox
  */
 final case class EnumSelect[A](
-  label:          String,
   value:          Option[A],
+  label:          String = "",
   placeholder:    String = "",
   disabled:       Boolean = false,
   onChange:       A ==> Callback = ((_: A) => Callback.empty).reuseAlways,

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ChangeAuditor.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ChangeAuditor.scala
@@ -47,8 +47,8 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
   /**
    * Accept if the string meets the condition.
    *
-   * @param strs
-   *   - The list of strings to check for.
+   * @param cond
+   *   - Condition to check for.
    */
   def allow(cond: String => Boolean): ChangeAuditor[A] = ChangeAuditor { (s, c) =>
     if (cond(s)) AuditResult.accept else self.audit(s, c)
@@ -57,8 +57,8 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
   /**
    * Reject if the string meets the condition.
    *
-   * @param strs
-   *   - The list of strings to check for.
+   * @param cond
+   *   - Condition to check for.
    */
   def deny(cond: String => Boolean): ChangeAuditor[A] = ChangeAuditor { (s, c) =>
     if (cond(s)) AuditResult.reject else self.audit(s, c)

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ChangeAuditor.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ChangeAuditor.scala
@@ -7,7 +7,11 @@ import cats.data.Validated._
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.{ Validate => RefinedValidate }
-import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.optics._
+import lucuma.ui.optics.FormatUtils._
 import lucuma.ui.optics.TruncatedDec
 import lucuma.ui.optics.TruncatedRA
 import mouse.all._
@@ -33,13 +37,31 @@ object FilterMode {
 final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
 
   /**
-   * Converts a ChangeAuditor[A] into a ChangeAuditor[Option[A]]. It unconditionally allows spaces.
-   * This is useful when using a ChangeAuditor made from a Format, but the model field is optional.
-   * Hint: If you're going to chain this together with another "modifier" like 'int', you want this
-   * one last.
+   * Allows you to treat the current ChangeAuditor as though it is for a different type. Useful, for
+   * example, if you can't directly use a Format for a type because you have to allow interim
+   * invalid values while typing. You can use something like a BigDecimal auditor and then call
+   * this.
    */
-  def optional: ChangeAuditor[Option[A]] = ChangeAuditor { (s, c) =>
-    if (s == "") AuditResult.accept else self.audit(s, c)
+  def as[B] = ChangeAuditor[B]((s, c) => self.audit(s, c))
+
+  /**
+   * Accept if the string meets the condition.
+   *
+   * @param strs
+   *   - The list of strings to check for.
+   */
+  def allow(cond: String => Boolean): ChangeAuditor[A] = ChangeAuditor { (s, c) =>
+    if (cond(s)) AuditResult.accept else self.audit(s, c)
+  }
+
+  /**
+   * Reject if the string meets the condition.
+   *
+   * @param strs
+   *   - The list of strings to check for.
+   */
+  def deny(cond: String => Boolean): ChangeAuditor[A] = ChangeAuditor { (s, c) =>
+    if (cond(s)) AuditResult.reject else self.audit(s, c)
   }
 
   /**
@@ -50,26 +72,54 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
    * "" as zero. Hint: If you're going to chain this together with another "modifier" like 'int',
    * you probably want this one last.
    */
-  def allowEmpty: ChangeAuditor[A] = ChangeAuditor { (s, c) =>
-    if (s == "") AuditResult.accept else self.audit(s, c)
-  }
+  def allowEmpty: ChangeAuditor[A] = allow(_.isEmpty)
 
   /**
-   * Unconditionally allows the field to be a minus sign. This is used by the `int` and `decimal`
-   * modifiers below, but could possibly be useful elsewhere.
+   * Converts a ChangeAuditor[A] into a ChangeAuditor[Option[A]]. It unconditionally allows spaces.
+   * This is useful when using a ChangeAuditor made from a Format, but the model field is optional.
+   * Hint: If you're going to chain this together with another "modifier" like 'int', you want this
+   * one last.
    */
-  def allowMinus: ChangeAuditor[A] = ChangeAuditor { (s, c) =>
-    if (s == "-") AuditResult.accept else self.audit(s, c)
-  }
+  def optional: ChangeAuditor[Option[A]] = allowEmpty.as[Option[A]]
 
   /**
-   * Reject if the string contains any of the strings in the parameters.
-   *
-   * @param strs
-   *   - The list of strings to check for.
+   * Unconditionally allows the field to start with minus sign. This is used by the `int` and
+   * `decimal` modifiers below, but could possibly be useful elsewhere.
    */
-  def deny(strs: String*): ChangeAuditor[A] = ChangeAuditor { (s, c) =>
-    if (strs.exists(s.contains)) AuditResult.reject else self.audit(s, c)
+  def allowNeg: ChangeAuditor[A] = allow(_.startsWith("-"))
+
+  /**
+   * Unconditionally prevents the field from starting with minus sign. This is used by the `int` and
+   * `decimal` modifiers below, but could possibly be useful elsewhere.
+   */
+  def denyNeg: ChangeAuditor[A] = deny(_.startsWith("-"))
+
+  /**
+   * Allows a numeric field to have an exponential part (ie.: e10, e+10 or e-10). Numeric fields
+   * don't allow this unless explicitly enabled with this method.
+   */
+  def allowExp(digits: PosInt = 2): ChangeAuditor[A] = {
+    val SplitExp = s"^([^e]*)((?:e[\\+-]?)?)((?:[1-9]\\d{0,${digits.value - 1}})?)$$".r
+
+    ChangeAuditor { (s, c) =>
+      s match {
+        case SplitExp(base, e, exp) =>
+          val expAudit = ChangeAuditor.int.audit(exp, c - base.length - e.length)
+          self.audit(base, c.max(base.length)) match {
+            case AuditResult.Accept                       => expAudit
+            case AuditResult.NewString(newString, cursor) =>
+              expAudit match {
+                case AuditResult.Accept                     => AuditResult.NewString(newString + e + exp, cursor)
+                case AuditResult.NewString(newExpString, _) =>
+                  AuditResult.NewString(newString + e + newExpString, cursor)
+                case _                                      => AuditResult.reject
+              }
+            case _                                        => AuditResult.reject
+          }
+        case _                      =>
+          AuditResult.reject
+      }
+    }
   }
 
   /**
@@ -86,7 +136,7 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
       val (result, newS, newC) = ChangeAuditor.processIntString(s, c)
       self.checkAgainstSelf(newS, newC, result)
     }
-    if (allowNeg) auditor.allowMinus else auditor.deny("-")
+    if (allowNeg) auditor.allowNeg else auditor.denyNeg
   }
 
   /**
@@ -94,7 +144,7 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
    * "original" ChangeAuditor. This is useful when using a ChangeAuditor made from a format to get
    * better behavior for entering values.
    */
-  def decimal(decimals: Int Refined Positive): ChangeAuditor[A] = {
+  def decimal(decimals: PosInt): ChangeAuditor[A] = {
     // Check to see if negative values are allowed. If this causes
     // problems, we may need to make the check optional.
     val negStr   = "-0." + "0" * (decimals.value - 1) + "1"
@@ -104,16 +154,8 @@ final case class ChangeAuditor[A](audit: (String, Int) => AuditResult) { self =>
       val (result, newS, newC) = ChangeAuditor.processDecimalString(s, c, decimals)
       self.checkAgainstSelf(newS, newC, result)
     }
-    if (allowNeg) auditor.allowMinus else auditor.deny("-")
+    if (allowNeg) auditor.allowNeg else auditor.denyNeg
   }
-
-  /**
-   * Allows you to treat the current ChangeAuditor as though it is for a different type. Useful, for
-   * example, if you can't directly use a Format for a type because you have to allow interim
-   * invalid values while typing. You can use something like a BigDecimal auditor and then call
-   * this.
-   */
-  def as[B] = ChangeAuditor[B]((s, c) => self.audit(s, c))
 
   private def checkAgainstSelf(str: String, cursor: Int, result: AuditResult): AuditResult = {
     def rejectOrPassOn(s: String, c: Int) = audit(s, c) match {
@@ -142,7 +184,7 @@ object ChangeAuditor {
   /**
    * For a string. Simply limits the length of the input string.
    */
-  def maxLength(max: Int Refined Positive): ChangeAuditor[String] = ChangeAuditor { (str, _) =>
+  def maxLength(max: PosInt): ChangeAuditor[String] = ChangeAuditor { (str, _) =>
     if (str.length > max.value) AuditResult.reject else AuditResult.accept
   }
 
@@ -150,20 +192,116 @@ object ChangeAuditor {
    * For a plain integer. Only allows entry of numeric values. ALlows the input to be empty or "-",
    * etc. to make entry easier. It also strips leading zeros.
    */
-  def int: ChangeAuditor[Int] = ChangeAuditor { (str, cursorPos) =>
+  val int: ChangeAuditor[Int] = ChangeAuditor { (str, cursorPos) =>
     processIntString(str, cursorPos)._1
   }
 
   /**
-   * For a big decimal. ALlows the input to be empty or "-", etc. to make entry easier. It also
+   * For a plain positive integer. Only allows entry of numeric values. ALlows the input to be
+   * empty, etc. to make entry easier. It also strips leading zeros.
+   */
+  val posInt: ChangeAuditor[PosInt] = int.denyNeg.as[PosInt]
+
+  /**
+   * For a big decimal. Allows the input to be empty or "-", etc. to make entry easier. It also
    * strips leading and trailing zeros (past the number of allowed decimals).
+   *
+   * @param integers
+   *   - maximum number of allowed integer digits, or None for unbounded
+   * @param decimals
+   *   - maximum number of allowed decimals.
+   */
+  protected def bigDecimal(integers: Option[PosInt], decimals: PosInt): ChangeAuditor[BigDecimal] =
+    ChangeAuditor { (str, cursorPos) =>
+      val (result, formatStr, _) = processDecimalString(str, cursorPos, decimals)
+      result match {
+        case AuditResult.Accept                           =>
+          checkIntegerDigits(formatStr, integers)
+        case newString @ AuditResult.NewString(newStr, _) =>
+          checkIntegerDigits(newStr, integers) match {
+            case AuditResult.Accept => newString
+            case other              => other
+          }
+        case reject @ AuditResult.Reject                  => reject
+      }
+    }
+
+  /**
+   * For a big decimal. Allows the input to be empty or "-", etc. to make entry easier. It also
+   * strips leading and trailing zeros (past the number of allowed decimals). Allows an unbounded
+   * number of integer digits.
    *
    * @param decimals
    *   - maximum number of allowed decimals.
    */
-  def bigDecimal(decimals: Int Refined Positive): ChangeAuditor[BigDecimal] = ChangeAuditor {
-    (str, cursorPos) => processDecimalString(str, cursorPos, decimals)._1
-  }
+  @inline
+  def bigDecimal(decimals: PosInt = 3): ChangeAuditor[BigDecimal] =
+    bigDecimal(none, decimals)
+
+  /**
+   * For a big decimal. Allows the input to be empty or "-", etc. to make entry easier. It also
+   * strips leading and trailing zeros (past the number of allowed decimals).
+   *
+   * @param integers
+   *   - maximum number of allowed integer digits
+   * @param decimals
+   *   - maximum number of allowed decimals.
+   */
+  @inline
+  def bigDecimal(integers: PosInt, decimals: PosInt): ChangeAuditor[BigDecimal] =
+    bigDecimal(integers.some, decimals)
+
+  /**
+   * For a big decimal. Allows the input to be empty, etc. to make entry easier. It also strips
+   * leading and trailing zeros (past the number of allowed decimals).
+   *
+   * @param integers
+   *   - maximum number of allowed integer digits, or None for unbounded
+   * @param decimals
+   *   - maximum number of allowed decimals.
+   */
+
+  @inline
+  def posBigDecimal(integers: Option[PosInt], decimals: PosInt): ChangeAuditor[PosBigDecimal] =
+    bigDecimal(integers, decimals).denyNeg.as[PosBigDecimal]
+
+  /**
+   * For a big decimal. Allows the input to be empty, etc. to make entry easier. It also strips
+   * leading and trailing zeros (past the number of allowed decimals). Allows an unbounded number of
+   * integer digits.
+   *
+   * @param decimals
+   *   - maximum number of allowed decimals.
+   */
+  @inline
+  def posBigDecimal(decimals: PosInt = 3): ChangeAuditor[PosBigDecimal] =
+    posBigDecimal(none, decimals)
+
+  /**
+   * For a positive big decimal. Allows the input to be empty, etc. to make entry easier. It also
+   * strips leading and trailing zeros (past the number of allowed decimals).
+   *
+   * @param integers
+   *   - maximum number of allowed integer digits, or None for unbounded
+   * @param decimals
+   *   - maximum number of allowed decimals.
+   */
+  @inline
+  def posBigDecimal(integers: PosInt, decimals: PosInt): ChangeAuditor[PosBigDecimal] =
+    posBigDecimal(integers.some, decimals)
+
+  def scientificNotation(
+    decimals:       PosInt = 3,
+    exponentDigits: PosInt = 2
+  ): ChangeAuditor[BigDecimal] =
+    bigDecimal(1, decimals).allowExp(exponentDigits)
+
+  @inline
+  def posScientificNotation(
+    decimals:       PosInt = 3,
+    exponentDigits: PosInt = 2
+  ): ChangeAuditor[PosBigDecimal] =
+    scientificNotation(decimals, exponentDigits).denyNeg.as[PosBigDecimal]
 
   /**
    * For Refined Ints. Only allows entry of numeric values.
@@ -195,8 +333,8 @@ object ChangeAuditor {
       }
     }
 
-    if (filterMode == Lax || ValidFormat.refinedPrism[Int, P].getOption(-1).isDefined) auditor
-    else auditor.deny("-")
+    if (filterMode == Lax || refinedPrism[Int, P].getOption(-1).isDefined) auditor
+    else auditor.denyNeg
   }
 
   /**
@@ -316,9 +454,9 @@ object ChangeAuditor {
   private def processDecimalString(
     str:       String,
     cursorPos: Int,
-    decimals:  Int Refined Positive
+    decimals:  PosInt
   ): (AuditResult, String, Int) = {
-    val (formatStr, newStr, offset) = fixDecimalString(str, cursorPos, decimals.value)
+    val (formatStr, newStr, offset) = fixDecimalString(str, cursorPos, decimals)
 
     val result =
       if (hasNDecimalsOrFewer(newStr, decimals.value))
@@ -335,7 +473,7 @@ object ChangeAuditor {
   private def fixDecimalString(
     str:       String,
     cursorPos: Int,
-    decimals:  Int
+    decimals:  PosInt
   ): (String, String, Int) = {
     val postStripped = stripZerosPastNPlaces(str, decimals)
     postStripped match {
@@ -347,14 +485,6 @@ object ChangeAuditor {
         val dp = postStripped.indexOf(".")
         val n  = if (dp < 0) cursorPos else math.min(dp, cursorPos)
         stripZerosBeforeN(postStripped, n)
-    }
-  }
-
-  private def stripZerosPastNPlaces(str: String, n: Int): String = {
-    val regex = s"(.*\\.\\d{0,$n}[1-9]*)+0*".r
-    str match {
-      case regex(base) => base
-      case _           => str
     }
   }
 
@@ -385,6 +515,20 @@ object ChangeAuditor {
     else
       str.length <= maxDigits && str.parseIntOption
         .exists(i => 0 <= i && i <= maxValue)
+
+  private def integerDigits(str: String): Int = {
+    val Integers = "-?(\\d*).*".r
+    str match {
+      case Integers(digits) => digits.length
+      case _                => 0
+    }
+  }
+
+  private def checkIntegerDigits(str: String, digitsOpt: Option[PosInt]): AuditResult =
+    digitsOpt.fold(AuditResult.accept)(digits =>
+      if (integerDigits(str) <= digits.value) AuditResult.accept
+      else AuditResult.reject
+    )
 
   private def isValidSeconds(str: String, decimals: Int): Boolean =
     if (str == "") true

--- a/modules/ui/src/main/scala/lucuma/ui/optics/FormatUtils.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/FormatUtils.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import eu.timepit.refined.types.numeric.NonNegInt
+
+object FormatUtils {
+
+  /** If the string represents a decimal number, strip trailing zeros past `n` decimal places. */
+  def stripZerosPastNPlaces(str: String, n: NonNegInt): String = {
+    val regex = s"(.*\\.\\d{0,${n.value}}\\d*?)0*".r
+    str match {
+      case regex(base) => base
+      case _           => str
+    }
+  }
+}

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormat.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormat.scala
@@ -7,9 +7,7 @@ import cats.data.Validated
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.{ Validate => RefinedValidate }
-import eu.timepit.refined.refineV
-import lucuma.core.optics.Format
-import lucuma.core.optics.SplitEpi
+import lucuma.core.optics._
 import monocle.Iso
 import monocle.Prism
 
@@ -123,7 +121,4 @@ object ValidFormat {
     v:                           RefinedValidate[A, P]
   ): ValidFormat[E, A, A Refined P] =
     fromPrism(refinedPrism[A, P], error)
-
-  def refinedPrism[A, P](implicit v: RefinedValidate[A, P]): Prism[A, A Refined P] =
-    Prism[A, A Refined P](i => refineV[P](i).toOption)(_.value)
 }

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormatInputInstances.scala
@@ -36,14 +36,14 @@ trait ValidFormatInputInstances {
     _.toString
   )
 
-  // does not, and cannot, format to a particular number of decimal places. For that
+  // Does not, and cannot, format to a particular number of decimal places. For that
   // you need a TruncatedBigDecimal.
   def bigDecimalValidFormat(errorMessage: NonEmptyString = "Must be a number") =
     ValidFormatInput[BigDecimal](
       s =>
         fixDecimalString(s).parseBigDecimalOption
           .fold(errorMessage.invalidNec[BigDecimal])(_.validNec),
-      _.toString
+      _.toString.toLowerCase.replace("+", "") // Strip + sign from exponent.
     )
 
   def truncatedBigDecimalValidFormat[Dec <: XInt](

--- a/modules/ui/src/test/scala/lucuma/ui/optics/FormatUtilsSpec.scala
+++ b/modules/ui/src/test/scala/lucuma/ui/optics/FormatUtilsSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.optics
+
+import eu.timepit.refined.types.numeric.NonNegInt
+import lucuma.ui.optics.FormatUtils._
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+final class FormatUtilsSpec extends DisciplineSuite {
+  val Zero = BigInt(0)
+  test("stripZerosPastNPlaces") {
+    forAll(arbitrary[BigInt], Gen.choose(0, 999999), Gen.choose(0, 9), Gen.choose(0, 9)) {
+      (i, d0, n0, z) =>
+        val d    = d0.toString + "0" * z
+        val keep = d.take(n0) + d.drop(n0).reverse.dropWhile(_ == '0').reverse
+        val n    = NonNegInt.unsafeFrom(n0)
+        assertEquals(stripZerosPastNPlaces(s"$i.$d", n), s"$i.$keep")
+    }
+  }
+}


### PR DESCRIPTION
- Introduces `ValidFormatInput.forScientificNotation(Pos)BigDecimal`.
- Introduces `ChangeAuditor.(pos)scientificNotation`.
- Introduces `ChangeAuditor.[posInt,posBigDecimal]`.
- `ChangeAuditor.(pos)bigDecimal` allow specifying number of integer digits.
- Adds `.optional` to `ValidFormatInput`, removing `fromFormatOptional` (which can now be achieved with `fromFormat(…).optional`.
- `ChangeAuditor.[allow,deny]` now take a predicate as parameter.
- `[allow,deny]Neg` now replace previous `allowMinus`. For exponential notation, we want to allow a minus sign in the exponent even if we don’t accept negative numbers.
- Internal method `ChangeAuditor.stripZerosPastNPlaces` was moved to another module `FormatUtils` in order to add tests. The idea is to eventually move other internal utility methods here and add tests, but for the moment only this one is migrated.
- `label` now optional in `EnumSelect`.