### PR TITLE
More convenience methods.

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/implicits/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/implicits/package.scala
@@ -5,18 +5,30 @@ package lucuma.ui
 
 import cats.Monad
 import crystal.ViewF
+import crystal.ViewOptF
 import crystal.react.reuse.Reuse
 import lucuma.core.optics.SplitEpi
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
 package object implicits {
-  implicit class ViewFOpticOps[F[_], A](val self: ViewF[F, A])             extends AnyVal {
+  implicit class ViewFOpticOps[F[_], A](val self: ViewF[F, A]) extends AnyVal {
     def zoomSplitEpi[B](splitEpi: SplitEpi[A, B]): ViewF[F, B] =
       self.zoom(splitEpi.get)(splitEpi.modify)
   }
+
+  implicit class ViewOptFOpticOps[F[_], A](val self: ViewOptF[F, A]) extends AnyVal {
+    def zoomSplitEpi[B](splitEpi: SplitEpi[A, B]): ViewOptF[F, B] =
+      self.zoom(splitEpi.get)(splitEpi.modify)
+  }
+
   implicit class ReuseViewFOpticOps[F[_], A](val self: Reuse[ViewF[F, A]]) extends AnyVal {
     def zoomSplitEpi[B](splitEpi: SplitEpi[A, B])(implicit ev: Monad[F]): Reuse[ViewF[F, B]] =
+      self.zoom(splitEpi.get)(splitEpi.modify)
+  }
+
+  implicit class ReuseViewOptFOpticOps[F[_], A](val self: Reuse[ViewOptF[F, A]]) extends AnyVal {
+    def zoomSplitEpi[B](splitEpi: SplitEpi[A, B])(implicit ev: Monad[F]): Reuse[ViewOptF[F, B]] =
       self.zoom(splitEpi.get)(splitEpi.modify)
   }
 

--- a/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormat.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/optics/ValidFormat.scala
@@ -65,11 +65,25 @@ abstract class ValidFormat[E, T, A] extends Serializable { self =>
   def andThen[B](f: SplitEpi[A, B], error: E): ValidFormat[E, T, B] =
     andThen(ValidFormat.fromFormat(f.asFormat, error))
 
-  // /** Format is an invariant functor over A. */
+  /** Compose with a SplitMono. */
+  def andThen[B](f: SplitMono[A, B]): ValidFormat[E, T, B] =
+    ValidFormat(
+      getValidated(_).map(f.get),
+      reverseGet.compose(f.reverseGet)
+    )
+
+  /** Compose with a Wedge. */
+  def andThen[B](f: Wedge[A, B]): ValidFormat[E, T, B] =
+    ValidFormat(
+      getValidated(_).map(f.get),
+      reverseGet.compose(f.reverseGet)
+    )
+
+  // /** ValidFormat is an invariant functor over A. */
   def imapA[B](f: B => A, g: A => B): ValidFormat[E, T, B] =
     ValidFormat(getValidated(_).map(g), f.andThen(reverseGet))
 
-  // /** Format is an invariant functor over T. */
+  // /** ValidFormat is an invariant functor over T. */
   def imapT[S](f: T => S, g: S => T): ValidFormat[E, S, A] =
     ValidFormat(g.andThen(getValidated), reverseGet.andThen(f))
 }


### PR DESCRIPTION
- `(Reuse)ViewOpt.zoomSplitEpi`.
- `ValidFormat.andThen(SplitMono)`.
- `ValidFormat.andThen(Wedge)`.