### PR TITLE
Replicate SUI button sizes as used in Explore in primereact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.50"
+ThisBuild / tlBaseVersion       := "0.51"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -27,13 +27,68 @@
   }
 }
 
-// For styling of buttons in primereact for different "compactness"
+// For styling of buttons in primereact for different "compactness" and "size"
 button.p-component.p-button {
   margin-right: .25em; // this is what the current css does for SUI. Might want to improve.
 
-  // Probably will need to 'specialize' for small and large buttons, and compact vs very compact
-  &.pl-compact,
-  &.pl-very-compact {
-    padding: .4em .5em;
+  &.pl-compact {
+    padding: 0.39285714em;
+  }
+
+  svg.svg-inline--fa {
+    width: 1.5em;
+  }
+
+  .p-button-icon-left {
+    margin-right: 0.2em;
+  }
+
+  .p-button-icon-right {
+    margin-left: 0.2em;
+  }
+
+  // default size is Medium
+  &.pl-mini {
+    font-size: 0.78571429rem;
+  }
+
+  &.pl-tiny {
+    font-size: 0.85714286rem;
+  }
+
+  &.p-button-sm,
+  &.pl-small {
+    font-size: 0.92857143rem;
+  }
+
+  &.p-button-lg,
+  &.pl-large {
+    font-size: 1.14285714rem;
+  }
+
+  // unfortunately, primereact uses `scaling factors` to scala the `lg` and `sm` component. It also 
+  // seems to apply these to padding, which we don't want. Change the scaling factors seemed inappropriate
+  // because it would affect many more componenents, so I had to copy the padding value for the medium button.
+  &.p-button-sm,
+  &.p-button-lg {
+    &:not(.pl-compact) {
+      padding: 0.78571429em;
+    }
+
+    .p-button-icon {
+      font-size: inherit;
+    }
+  }
+
+  &.pl-big {
+    font-size: 1.28571429rem;
+  }
+
+  &.pl-huge {
+    font-size: 1.42857143rem;
+  }
+
+  &.pl-massive {
+    font-size: 1.71428571rem;
   }
 }

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
@@ -8,8 +8,20 @@ import react.common._
 
 trait LucumaStyles {
 
+  // compact is used for form columns and buttons
   val Compact: Css     = Css("pl-compact")
+  // not used for buttons, at least not at the moment
   val VeryCompact: Css = Css("pl-very-compact")
+
+  // currently used for buttons
+  val Mini: Css    = Css("pl-mini")
+  val Tiny: Css    = Css("pl-tiny")
+  val Small: Css   = Css("pl-small")
+  val Medium: Css  = Css("pl-medium")
+  val Large: Css   = Css("pl-large")
+  val Big: Css     = Css("pl-big")
+  val Huge: Css    = Css("pl-huge")
+  val Massive: Css = Css("pl-massive")
 
   val FormColumn: Css            = Css("pl-form-column")
   val FormColumnCompact: Css     = FormColumn |+| Compact

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
@@ -11,5 +11,13 @@ import reactST.StBuildingComponent
 import scalajs.js
 
 extension (button: Button)
-  def compact     = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Compact)
-  def veryCompact = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.VeryCompact)
+  def compact = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Compact)
+
+  def mini    = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Mini)
+  def tiny    = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Tiny)
+  def small   = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Small)
+  def medium  = button // medium is the default
+  def large   = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Large)
+  def big     = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Big)
+  def huge    = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Huge)
+  def massive = button.copy(clazz = button.clazz.toOption.orEmpty |+| LucumaStyles.Massive)


### PR DESCRIPTION
This matches the SUI button sizes quite closely, but is even smaller than SUI for buttons without icons because I reduced the left and right padding on text only buttons to the same as the ones with buttons.