### PR TITLE
Add ability to set a class on the label to SliderView

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.53"
+ThisBuild / tlBaseVersion       := "0.54"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/SliderView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/SliderView.scala
@@ -16,18 +16,19 @@ import scalajs.js
 import scalajs.js.JSConverters.*
 
 case class SliderView(
-  id:       NonEmptyString,
-  value:    View[Double],
-  label:    String,
-  disabled: js.UndefOr[Boolean] = js.undefined,
-  clazz:    js.UndefOr[Css] = js.undefined
+  id:         NonEmptyString,
+  value:      View[Double],
+  label:      String,
+  disabled:   js.UndefOr[Boolean] = js.undefined,
+  clazz:      js.UndefOr[Css] = js.undefined,
+  labelClass: js.UndefOr[Css] = js.undefined
 ) extends ReactFnProps(SliderView.component)
 
 object SliderView {
   private val component = ScalaFnComponent[SliderView] { props =>
     <.div(
       props.clazz.getOrElse(Css.Empty),
-      <.label(^.htmlFor := props.id.value, props.label),
+      <.label(^.htmlFor := props.id.value, props.label, props.labelClass.toOption.orEmpty),
       Slider(id = props.id.value,
              value = props.value.get,
              onChange = props.value.set,


### PR DESCRIPTION
If we are ever going to want to use the slider view in a `FormColumn` with the label and slider in the appropriate places, we'll want to be able to set the `FormFieldLabel` on the label. 