### PR TITLE
Get rid of unique key error for FormInputText addons

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputText.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputText.scala
@@ -44,7 +44,7 @@ object FormInputText {
   private val component = ScalaFnComponent[FormInputText] { props =>
     val group = <.div(
       PrimeStyles.InputGroup |+| LucumaStyles.FormField |+| props.groupClass.toOption.orEmpty,
-      props.preAddons.toVdomArray(p =>
+      props.preAddons.toTagMod(p =>
         (p: Any) match {
           case b: CButton.Builder => b.build
           case t: TagMod          =>
@@ -62,12 +62,11 @@ object FormInputText {
         onKeyDown = props.onKeyDown,
         modifiers = props.modifiers
       ),
-      props.postAddons.zipWithIndex.toVdomArray { (p, i) =>
-        val key = s"${props.id.value}-post-add-on-$i"
+      props.postAddons.toTagMod { p =>
         (p: Any) match {
-          case b: CButton.Builder => b.withKey(key).build
+          case b: CButton.Builder => b.build
           case t: TagMod          =>
-            <.span(^.key := key, t, Css("p-inputgroup-addon"))
+            <.span(t, Css("p-inputgroup-addon"))
         }
       }
     )


### PR DESCRIPTION
This fixes the "items in a list should have a unique key" error from React when using `preAddons` in the FormTextInput. An earlier fix for `postAddons` was made earlier, and I modified it to be the same as this fix.