### PR TITLE
Add a primereact EnumDropdown

### DIFF
--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -43,6 +43,12 @@
   }
 }
 
+// Make the dropdown size match the input, and the input group addons, too
+.p-component.p-dropdown .p-dropdown-label.p-inputtext,
+.p-inputgroup .p-inputgroup-addon {
+  line-height: 1.15;
+}
+
 // For styling of buttons in primereact for different "compactness" and "size"
 button.p-component.p-button {
   margin-right: .25em; // this is what the current css does for SUI. Might want to improve.

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/EnumDropdown.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/EnumDropdown.scala
@@ -3,7 +3,7 @@
 
 package lucuma.ui.primereact
 
-import crystal.react.View
+import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^._
@@ -16,40 +16,44 @@ import react.primereact.SelectItem
 import scalajs.js
 import scalajs.js.JSConverters.*
 
-final case class EnumDropdownView[A](
-  id:              NonEmptyString,
-  value:           View[A],
-  exclude:         Set[A] = Set.empty[A],
-  clazz:           js.UndefOr[Css] = js.undefined,
-  filter:          js.UndefOr[Boolean] = js.undefined,
-  showFilterClear: js.UndefOr[Boolean] = js.undefined,
-  disabled:        js.UndefOr[Boolean] = js.undefined,
-  placeholder:     js.UndefOr[String] = js.undefined,
-  modifiers:       Seq[TagMod] = Seq.empty
-)(using
-  val enumerated:  Enumerated[A],
-  val display:     Display[A]
-) extends ReactFnProps[EnumDropdownView[Any]](EnumDropdownView.component):
+case class EnumDropdown[A](
+  id:                   NonEmptyString,
+  value:                A,
+  exclude:              Set[A] = Set.empty[A],
+  disabledItems:        Set[A] = Set.empty[A],
+  clazz:                js.UndefOr[Css] = js.undefined,
+  filter:               js.UndefOr[Boolean] = js.undefined,
+  showFilterClear:      js.UndefOr[Boolean] = js.undefined,
+  disabled:             js.UndefOr[Boolean] = js.undefined,
+  onChange:             js.UndefOr[A => Callback] = js.undefined,
+  placeholder:          js.UndefOr[String] = js.undefined,
+  modifiers:            Seq[TagMod] = Seq.empty
+)(using val enumerated: Enumerated[A], val display: Display[A])
+    extends ReactFnProps(EnumDropdown.component):
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
   def apply(mods:             TagMod*)     = addModifiers(mods)
 
-object EnumDropdownView {
-  private def buildComponent[A] = ScalaFnComponent[EnumDropdownView[A]] { props =>
+object EnumDropdown {
+  private def buildComponent[A] = ScalaFnComponent[EnumDropdown[A]] { props =>
     import props.given
 
     Dropdown(
-      value = props.value.get,
+      id = props.id.value,
+      value = props.value,
       options = props.enumerated.all
         .filter(v => !props.exclude.contains(v))
-        .map(e => SelectItem(label = props.display.shortName(e), value = e)),
-      id = props.id.value,
+        .map(e =>
+          SelectItem(label = props.display.shortName(e),
+                     value = e,
+                     disabled = props.disabledItems.contains(e)
+          )
+        ),
       clazz = props.clazz,
       filter = props.filter,
       showFilterClear = props.showFilterClear,
-      disabled = props.disabled,
       placeholder = props.placeholder,
-      onChange = v => props.value.set(v),
+      onChange = props.onChange,
       modifiers = props.modifiers
     )
   }

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownView.scala
@@ -49,6 +49,7 @@ object FormEnumDropdownView {
         clazz = LucumaStyles.FormField |+| props.clazz.toOption.orEmpty,
         filter = props.filter,
         showFilterClear = props.showFilterClear,
+        disabled = props.disabled,
         placeholder = props.placeholder,
         modifiers = props.modifiers
       )


### PR DESCRIPTION
Also fixes a bug with EnumDropdownView disable and makes line heights of inputs and dropdowns the same.