### PR TITLE
Add ViewLike and modify primereact controls to use it

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.56"
+ThisBuild / tlBaseVersion       := "0.57"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"
@@ -13,7 +13,7 @@ lazy val monocleVersion           = "3.1.0"
 lazy val mouseVersion             = "1.1.0"
 lazy val lucumaPrimeStylesVersion = "0.2.8"
 lazy val lucumaRefinedVersion     = "0.1.0"
-lazy val lucumaReactVersion       = "0.21.0"
+lazy val lucumaReactVersion       = "0.22.0"
 lazy val scalaJsReactVersion      = "2.1.1"
 lazy val pprintVersion            = "0.8.0"
 

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownOptionalView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownOptionalView.scala
@@ -4,21 +4,19 @@
 package lucuma.ui.primereact
 
 import cats.syntax.all.*
-import crystal.react.View
 import eu.timepit.refined.types.string.NonEmptyString
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import react.common.*
-import reactST.primereact.selectitemMod.SelectItem
 
 import scalajs.js
 import scalajs.js.JSConverters.*
 
-final case class FormEnumDropdownOptionalView[A](
+final case class FormEnumDropdownOptionalView[V[_], A](
   id:        NonEmptyString,
-  value:     View[Option[A]],
+  value:     V[Option[A]],
   label:     js.UndefOr[TagMod] = js.undefined,
   exclude:   Set[A] = Set.empty[A],
   clazz:     js.UndefOr[Css] = js.undefined,
@@ -31,32 +29,36 @@ final case class FormEnumDropdownOptionalView[A](
   modifiers:       Seq[TagMod] = Seq.empty
 )(using
   val enumerated:  Enumerated[A],
-  val display:     Display[A]
+  val display:     Display[A],
+  val vl:          ViewLike[V]
 ) extends ReactFnProps(FormEnumDropdownOptionalView.component):
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
   def apply(mods:             TagMod*)     = addModifiers(mods)
 
 object FormEnumDropdownOptionalView {
-  private def buildComponent[A] = ScalaFnComponent[FormEnumDropdownOptionalView[A]] { props =>
-    import props.given
+  private type AnyF[_] = Any
 
-    React.Fragment(
-      props.label.map(l => FormLabel(htmlFor = props.id)(l)),
-      EnumDropdownOptionalView(
-        id = props.id,
-        value = props.value,
-        exclude = props.exclude,
-        clazz = LucumaStyles.FormField |+| props.clazz.toOption.orEmpty,
-        showClear = props.showClear,
-        filter = props.filter,
-        showFilterClear = props.showFilterClear,
-        disabled = props.disabled,
-        placeholder = props.placeholder,
-        modifiers = props.modifiers
+  private def buildComponent[V[_], A] = ScalaFnComponent[FormEnumDropdownOptionalView[V, A]] {
+    props =>
+      import props.given
+
+      React.Fragment(
+        props.label.map(l => FormLabel(htmlFor = props.id)(l)),
+        EnumDropdownOptionalView(
+          id = props.id,
+          value = props.value,
+          exclude = props.exclude,
+          clazz = LucumaStyles.FormField |+| props.clazz.toOption.orEmpty,
+          showClear = props.showClear,
+          filter = props.filter,
+          showFilterClear = props.showFilterClear,
+          disabled = props.disabled,
+          placeholder = props.placeholder,
+          modifiers = props.modifiers
+        )
       )
-    )
   }
 
-  private val component = buildComponent[Any]
+  private val component = buildComponent[AnyF, Any]
 }

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormEnumDropdownView.scala
@@ -4,7 +4,6 @@
 package lucuma.ui.primereact
 
 import cats.syntax.all.*
-import crystal.react.View
 import eu.timepit.refined.types.string.NonEmptyString
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -12,14 +11,13 @@ import lucuma.core.enums.Half.A
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import react.common.*
-import reactST.primereact.selectitemMod.SelectItem
 
 import scalajs.js
 import scalajs.js.JSConverters.*
 
-final case class FormEnumDropdownView[A](
+final case class FormEnumDropdownView[V[_], A](
   id:              NonEmptyString,
-  value:           View[A],
+  value:           V[A],
   label:           js.UndefOr[String] = js.undefined,
   exclude:         Set[A] = Set.empty[A],
   clazz:           js.UndefOr[Css] = js.undefined,
@@ -30,14 +28,17 @@ final case class FormEnumDropdownView[A](
   modifiers:       Seq[TagMod] = Seq.empty
 )(using
   val enumerated:  Enumerated[A],
-  val display:     Display[A]
+  val display:     Display[A],
+  val vl:          ViewLike[V]
 ) extends ReactFnProps(FormEnumDropdownView.component):
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
   def apply(mods:             TagMod*)     = addModifiers(mods)
 
 object FormEnumDropdownView {
-  private def buildComponent[A] = ScalaFnComponent[FormEnumDropdownView[A]] { props =>
+  private type AnyF[_] = Any
+
+  private def buildComponent[V[_], A] = ScalaFnComponent[FormEnumDropdownView[V, A]] { props =>
     import props.given
 
     React.Fragment(
@@ -56,5 +57,5 @@ object FormEnumDropdownView {
     )
   }
 
-  private val component = buildComponent[Any]
+  private val component = buildComponent[AnyF, Any]
 }

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/ViewLike.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/ViewLike.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.primereact
+
+import cats.syntax.all.*
+import crystal.react.*
+import japgolly.scalajs.react.Callback
+
+trait ViewLike[VL[_]]:
+  extension [A](v: VL[A])
+    def get: Option[A]
+    def set(a: A): Callback
+
+given ViewLike[View] with
+  extension [A](v: View[A])
+    def get: Option[A] = v.get.some
+    def set(a: A): Callback = v.set(a)
+
+// Note that any ViewLike[ViewOpt] where the ViewOpt is None will never get set, it only provides
+// a way to have a UI until something else makes the ViewOpt a Some. Any control using
+// ViewLike[ViewOpt] should probably disabled when the ViewOpt is empty, or handled in some other way.
+given ViewLike[ViewOpt] with
+  extension [A](v: ViewOpt[A])
+    def get: Option[A] = v.get
+    def set(a: A): Callback = v.set(a)


### PR DESCRIPTION
This creates a new typeclass similar to `ExternalValue` and updates the controls for which it makes sense to use it. This allows the use of `ViewOpt` values instead of just `View`s.

The only change it requires in current user code is `import lucuma.ui.primereact.given`.

I didn't use `ExternalValue` because I wanted to use a scala 3 typeclass, and I didn't want to mess with updating the SUI controls to use it.