### PR TITLE
Add units to *InputTextViews and the ability to clear FormInputTextViews

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.61"
+ThisBuild / tlBaseVersion       := "0.62"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -229,13 +229,22 @@
   }
 }
 
-// clearable inputs
-.p-inputgroup.pl-clearable-input {
+// "blended" addons for inputtext groups. Includes units and the clearable icon.
+.p-inputgroup:has(.pl-blended-addon) {
+  .p-inputgroup-addon:has(.pl-blended-addon):has(+.p-inputgroup-addon),
   .p-inputtext {
     border-right: none;
   }
 
-  .p-inputgroup-addon:has(.pl-clear-button) {
+  .p-inputtext.p-disabled ~ .p-inputgroup-addon:has(.pl-blended-addon) {
+    opacity: 0.5;
+  }
+
+  .p-inputgroup-addon:has(.pl-blended-addon) {
+    border-left: none;
+  }
+
+  .p-inputgroup-addon:has(.pl-blended-addon) {
     background-color: var(--surface-0);
   }
 }

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -228,3 +228,14 @@
     }
   }
 }
+
+// clearable inputs
+.p-inputgroup.pl-clearable-input {
+  .p-inputtext {
+    border-right: none;
+  }
+
+  .p-inputgroup-addon:has(.pl-clear-button) {
+    background-color: var(--surface-0);
+  }
+}

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputText.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputText.scala
@@ -23,6 +23,7 @@ case class FormInputText(
   id:               NonEmptyString,
   value:            js.UndefOr[String] = js.undefined,
   label:            js.UndefOr[TagMod] = js.undefined,
+  units:            js.UndefOr[String] = js.undefined,
   preAddons:        List[TagMod | CButton.Builder] = List.empty,
   postAddons:       List[TagMod | CButton.Builder] = List.empty,
   size:             js.UndefOr[PlSize] = js.undefined,
@@ -41,6 +42,9 @@ case class FormInputText(
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
   def apply(mods:             TagMod*)     = addModifiers(mods)
+  def addPostAddons(addons: List[TagMod | CButton.Builder]) =
+    copy(postAddons = this.postAddons ++ addons)
+  def withPostAddons(addons: (TagMod | CButton.Builder)*) = addPostAddons(addons.toList)
 
 object FormInputText {
   private val component = ScalaFnComponent[FormInputText] { props =>
@@ -54,6 +58,11 @@ object FormInputText {
             <.span(t, PrimeStyles.InputGroupAddon |+| sizeCls)
         }
       )
+
+    // units are always first
+    val postAddons = props.units.fold(buildAddons(props.postAddons)) { units =>
+      buildAddons(<.span(^.cls := LucumaStyles.BlendedAddon.htmlClass, units) :: props.postAddons)
+    }
 
     val group = <.div(
       PrimeStyles.InputGroup |+| LucumaStyles.FormField |+| props.groupClass.toOption.orEmpty,
@@ -70,7 +79,7 @@ object FormInputText {
         onKeyDown = props.onKeyDown,
         modifiers = props.modifiers
       ),
-      buildAddons(props.postAddons)
+      postAddons
     )
 
     val input = props.tooltip.fold(group)(tt => group.withTooltip(tt, props.tooltipPlacement))

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputTextView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormInputTextView.scala
@@ -35,6 +35,7 @@ import scalajs.js.JSConverters._
 final case class FormInputTextView[V[_], A](
   id:            NonEmptyString,
   label:         js.UndefOr[TagMod] = js.undefined,
+  units:         js.UndefOr[String] = js.undefined,
   preAddons:     List[TagMod | CButton.Builder] = List.empty,
   postAddons:    List[TagMod | CButton.Builder] = List.empty,
   size:          js.UndefOr[PlSize] = js.undefined,
@@ -58,6 +59,9 @@ final case class FormInputTextView[V[_], A](
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
   def apply(mods:             TagMod*)     = addModifiers(mods)
+  def addPostAddons(addons: List[TagMod | CButton.Builder]) =
+    copy(postAddons = this.postAddons ++ addons)
+  def withPostAddons(addons: (TagMod | CButton.Builder)*) = addPostAddons(addons.toList)
 
 object FormInputTextView {
   type AnyF[_] = Any
@@ -208,6 +212,7 @@ object FormInputTextView {
         FormInputText(
           id = props.id,
           label = props.label,
+          units = props.units,
           size = props.size,
           groupClass = props.groupClass,
           inputClass =

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
@@ -33,8 +33,7 @@ trait LucumaStyles {
   val CheckboxWithLabel: Css    = Css("pl-checkbox-with-label")
   val RadioButtonWithLabel: Css = Css("pl-radiobutton-with-label")
 
-  val ClearableInput: Css = Css("pl-clearable-input")
-  val ClearButton: Css    = Css("pl-clear-button")
+  val BlendedAddon: Css = Css("pl-blended-addon")
 
   val IconPrefix: Css = Css("pi")
   val IconTimes: Css  = IconPrefix |+| Css("pi-times")

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
@@ -32,6 +32,12 @@ trait LucumaStyles {
 
   val CheckboxWithLabel: Css    = Css("pl-checkbox-with-label")
   val RadioButtonWithLabel: Css = Css("pl-radiobutton-with-label")
+
+  val ClearableInput: Css = Css("pl-clearable-input")
+  val ClearButton: Css    = Css("pl-clear-button")
+
+  val IconPrefix: Css = Css("pi")
+  val IconTimes: Css  = IconPrefix |+| Css("pi-times")
 }
 
 object LucumaStyles extends LucumaStyles

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
@@ -6,6 +6,8 @@ package lucuma.ui.primereact
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import crystal.react.View
+import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.Css
 import react.primereact.Button
 import react.primereact.InputText
@@ -44,3 +46,17 @@ extension (input: InputText)
   def big     = input.copy(clazz = input.clazz.toOption.orEmpty |+| LucumaStyles.Big)
   def huge    = input.copy(clazz = input.clazz.toOption.orEmpty |+| LucumaStyles.Huge)
   def massive = input.copy(clazz = input.clazz.toOption.orEmpty |+| LucumaStyles.Massive)
+
+extension [A](
+  input: FormInputTextView[View, Option[A]]
+)(using Eq[Option[A]])
+  def clearable: FormInputTextView[View, Option[A]] =
+    input.value.get.filter(_ => input.disabled.contains(false)).fold(input) { _ =>
+      val newAddon   =
+        <.span(^.cls := (LucumaStyles.ClearButton |+| LucumaStyles.IconTimes).htmlClass,
+               ^.onClick --> input.value.set(none)
+        )
+      val postAddons = newAddon :: input.postAddons
+      val groupClass = input.groupClass.toOption.orEmpty |+| LucumaStyles.ClearableInput
+      input.copy(postAddons = postAddons, groupClass = groupClass)
+    }

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/primereact.scala
@@ -52,11 +52,10 @@ extension [A](
 )(using Eq[Option[A]])
   def clearable: FormInputTextView[View, Option[A]] =
     input.value.get.filter(_ => input.disabled.contains(false)).fold(input) { _ =>
-      val newAddon   =
-        <.span(^.cls := (LucumaStyles.ClearButton |+| LucumaStyles.IconTimes).htmlClass,
+      val newAddon =
+        <.span(^.cls := (LucumaStyles.BlendedAddon |+| LucumaStyles.IconTimes).htmlClass,
                ^.onClick --> input.value.set(none)
         )
-      val postAddons = newAddon :: input.postAddons
-      val groupClass = input.groupClass.toOption.orEmpty |+| LucumaStyles.ClearableInput
-      input.copy(postAddons = postAddons, groupClass = groupClass)
+      // will go before other addons, but the units will still be first.
+      input.copy(postAddons = newAddon :: input.postAddons)
     }


### PR DESCRIPTION
This matches the appearance and behavior of the clearable dropdowns. The `X` only appears if the the input is not disabled and the value is non-empty.
<img width="340" alt="image" src="https://user-images.githubusercontent.com/6035943/209362511-fac02def-43a0-40b7-9d38-4e669385272b.png">
<img width="409" alt="image" src="https://user-images.githubusercontent.com/6035943/209362781-cff50131-d4de-4dc6-b50c-9bbdf19cca05.png">

