### PR TITLE
Linear form column style.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.63"
+ThisBuild / tlBaseVersion       := "0.64"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -22,7 +22,6 @@
   justify-items: start;
   align-items: baseline;
   align-self: start;
-  grid-template-columns: [label] auto [field] 1fr;
   row-gap: 1em;
   column-gap: 1em;
 
@@ -34,12 +33,19 @@
     row-gap: 0.25em;
   }
 
-  .pl-form-field-label {
-    grid-column: 1;
+  &:not(.pl-linear-column) {
+    grid-template-columns: [label] auto [field] 1fr;
+
+    .pl-form-field-label {
+      grid-column: 1;
+    }
+
+    .pl-form-field {
+      grid-column: 2;
+    }
   }
 
   .pl-form-field {
-    grid-column: 2;
     justify-self: stretch;
     margin: 0;
   }
@@ -170,19 +176,19 @@
   &.p-tooltip-right .p-tooltip-arrow {
     border-right-color: var(--text-color);
   }
-  
+
   &.p-tooltip-left .p-tooltip-arrow {
     border-left-color: var(--text-color);
   }
-  
+
   &.p-tooltip-top .p-tooltip-arrow {
     border-top-color: var(--text-color);
   }
-  
+
   &.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: var(--text-color);
   }
-  
+
   .p-tooltip-text {
     font-size: smaller;
     border: 1px solid var(--text-color);
@@ -242,7 +248,7 @@
     border-right: none;
   }
 
-  .p-inputtext.p-disabled ~ .p-inputgroup-addon:has(.pl-blended-addon) {
+  .p-inputtext.p-disabled~.p-inputgroup-addon:has(.pl-blended-addon) {
     opacity: 0.5;
   }
 

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormDropdown.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormDropdown.scala
@@ -56,7 +56,7 @@ object FormDropdown {
         id = props.id.value,
         value = props.value,
         options = props.options,
-        clazz = props.clazz,
+        clazz = LucumaStyles.FormField |+| props.clazz.toOption.orEmpty,
         panelClass = props.panelClass,
         filter = props.filter,
         showFilterClear = props.showFilterClear,

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormDropdownOptional.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormDropdownOptional.scala
@@ -57,7 +57,7 @@ object FormDropdownOptional {
         id = props.id.value,
         value = props.value,
         options = props.options,
-        clazz = props.clazz,
+        clazz = LucumaStyles.FormField |+| props.clazz.toOption.orEmpty,
         panelClass = props.panelClass,
         filter = props.filter,
         showFilterClear = props.showFilterClear,

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaStyles.scala
@@ -26,6 +26,7 @@ trait LucumaStyles {
   val FormColumn: Css            = Css("pl-form-column")
   val FormColumnCompact: Css     = FormColumn |+| Compact
   val FormColumnVeryCompact: Css = FormColumn |+| VeryCompact
+  val LinearColumn: Css          = Css("pl-linear-column")
 
   val FormField: Css      = Css("pl-form-field")
   val FormFieldLabel: Css = Css("pl-form-field-label")


### PR DESCRIPTION
Adds a `.pl-linear-column` class that can be combined with `.pl-form-column` to avoid forcing labels and fields into different grid columns.

This allows a row with the label followed by a row with the field.