### PR TITLE
Render typeclass, migrate extension methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.68"
+ThisBuild / tlBaseVersion       := "0.69"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui.scss
@@ -14,7 +14,7 @@
   --pl-big-font-size: 1.28571429rem;
   --pl-huge-font-size: 1.42857143rem;
   --pl-massive-font-size: 1.71428571rem;
- 
+
   // primereact does not provide a variable for this at all.
   --pl-input-line-height: 1.15;
   // This is available as a SASS variable in the primereact designer. Maybe we add our own
@@ -265,4 +265,16 @@
   .p-inputgroup-addon:has(.pl-blended-addon) {
     background-color: var(--surface-0);
   }
+}
+
+.pending-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: 0;
+  text-align: center;
+  z-index: 1000;
+  width: 4rem;
+  height: 4rem;
+  font-size: 1em;
 }

--- a/modules/ui/src/main/scala/lucuma/ui/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui
+
+import japgolly.scalajs.react.vdom.VdomNode
+import react.common.*
+import react.primereact.Message
+import react.primereact.ProgressSpinner
+
+val DefaultPendingRender: VdomNode = ProgressSpinner(clazz = Css("pending-loader"))
+
+val DefaultErrorRender: Throwable => VdomNode =
+  t => Message(text = t.getMessage, severity = Message.Severity.Error)

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/all.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/all.scala
@@ -3,4 +3,4 @@
 
 package lucuma.ui.syntax
 
-object all extends render with mod with css with util with view
+object all extends render with components with pot with mod with css with util with view

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/components.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/components.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.syntax
+
+import japgolly.scalajs.react.vdom.*
+import react.common.GenericComponentP
+import react.common.GenericComponentPA
+import react.common.GenericComponentPAC
+import react.common.GenericComponentPACF
+import react.common.GenericComponentPC
+import react.common.GenericFnComponentP
+import react.common.GenericFnComponentPA
+import react.common.GenericFnComponentPAC
+import react.common.GenericFnComponentPC
+
+import scala.scalajs.js
+import scala.scalajs.js.UndefOr
+
+trait components:
+  // Conversion of common components to VdomNode
+  type FnPA[P <: js.Object] = GenericFnComponentPA[P, ?]
+  given Conversion[FnPA[?], UndefOr[VdomNode]] = _.render
+  given Conversion[FnPA[?], VdomNode]          = _.render
+
+  type FnPAC[P <: js.Object] = GenericFnComponentPAC[P, ?]
+  given Conversion[FnPAC[?], UndefOr[VdomNode]] = _.render
+  given Conversion[FnPAC[?], VdomNode]          = _.render
+
+  type ClassPAC[P <: js.Object] = GenericComponentPAC[P, ?]
+  // Without the explicit `vdomElement` this produces a compiler exception
+  given Conversion[ClassPAC[?], UndefOr[VdomNode]] = _.render.vdomElement
+  given Conversion[ClassPAC[?], VdomNode]          = _.render.vdomElement
+
+  type ClassPC[P <: js.Object] = GenericComponentPC[P, ?]
+  given Conversion[ClassPC[?], UndefOr[VdomNode]] = _.render.vdomElement
+  given Conversion[ClassPC[?], VdomNode]          = _.render.vdomElement
+
+  type ClassPA[P <: js.Object] = GenericComponentPA[P, ?]
+  given Conversion[ClassPA[?], UndefOr[VdomNode]] = _.render.vdomElement
+  given Conversion[ClassPA[?], VdomNode]          = _.render.vdomElement
+
+  type ClassPACF[P <: js.Object, F <: js.Object] = GenericComponentPACF[P, ?, F]
+  given Conversion[ClassPACF[?, ?], VdomNode] = _.render.vdomElement
+
+  type ClassP[P <: js.Object] = GenericComponentP[P]
+  given Conversion[ClassP[?], UndefOr[VdomNode]] = _.render.vdomElement
+  given Conversion[ClassP[?], VdomNode]          = _.render.vdomElement
+
+  type FnP[P <: js.Object] = GenericFnComponentP[P]
+  given Conversion[FnP[?], VdomNode] = _.render
+
+object components extends components

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/pot.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/pot.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.syntax
+
+import crystal.Pot
+import crystal.PotOption
+import crystal.react.View
+import japgolly.scalajs.react.vdom.*
+import lucuma.ui.DefaultErrorRender
+import lucuma.ui.DefaultPendingRender
+
+trait pot:
+  // Pot and friends convenience rendering methods
+  extension [A](pot: Pot[A])
+    inline def renderPot(
+      valueRender:   A => VdomNode,
+      pendingRender: => VdomNode = DefaultPendingRender,
+      errorRender:   Throwable => VdomNode = DefaultErrorRender
+    ): VdomNode =
+      pot.fold(pendingRender, errorRender, valueRender)
+
+  extension [A](potView: View[Pot[A]])
+    inline def renderPotView(
+      valueRender:   A => VdomNode,
+      pendingRender: => VdomNode = DefaultPendingRender,
+      errorRender:   Throwable => VdomNode = DefaultErrorRender
+    ): VdomNode =
+      potView.get.renderPot(valueRender, pendingRender, errorRender)
+
+  extension [A](po: PotOption[A])
+    inline def renderPotOption(
+      valueRender:   A => VdomNode,
+      pendingRender: => VdomNode = DefaultPendingRender,
+      errorRender:   Throwable => VdomNode = DefaultErrorRender
+    ): VdomNode = po.toPot.renderPot(valueRender, pendingRender, errorRender)
+
+object pot extends pot

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/render.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/render.scala
@@ -4,51 +4,10 @@
 package lucuma.ui.syntax
 
 import japgolly.scalajs.react.vdom.*
-import japgolly.scalajs.react.vdom.html_<^.*
-import react.common.GenericComponentP
-import react.common.GenericComponentPA
-import react.common.GenericComponentPAC
-import react.common.GenericComponentPACF
-import react.common.GenericComponentPC
-import react.common.GenericFnComponentP
-import react.common.GenericFnComponentPA
-import react.common.GenericFnComponentPAC
-import react.common.GenericFnComponentPC
-
-import scala.scalajs.js
-import scala.scalajs.js.UndefOr
+import lucuma.ui.utils.Render
 
 trait render:
-  // Conversion of common components to VdomNode
-  type FnPA[P <: js.Object] = GenericFnComponentPA[P, ?]
-  given Conversion[FnPA[?], UndefOr[VdomNode]] = _.render
-  given Conversion[FnPA[?], VdomNode]          = _.render
-
-  type FnPAC[P <: js.Object] = GenericFnComponentPAC[P, ?]
-  given Conversion[FnPAC[?], UndefOr[VdomNode]] = _.render
-  given Conversion[FnPAC[?], VdomNode]          = _.render
-
-  type ClassPAC[P <: js.Object] = GenericComponentPAC[P, ?]
-  // Without the explicit `vdomElement` this produces a compiler exception
-  given Conversion[ClassPAC[?], UndefOr[VdomNode]] = _.render.vdomElement
-  given Conversion[ClassPAC[?], VdomNode]          = _.render.vdomElement
-
-  type ClassPC[P <: js.Object] = GenericComponentPC[P, ?]
-  given Conversion[ClassPC[?], UndefOr[VdomNode]] = _.render.vdomElement
-  given Conversion[ClassPC[?], VdomNode]          = _.render.vdomElement
-
-  type ClassPA[P <: js.Object] = GenericComponentPA[P, ?]
-  given Conversion[ClassPA[?], UndefOr[VdomNode]] = _.render.vdomElement
-  given Conversion[ClassPA[?], VdomNode]          = _.render.vdomElement
-
-  type ClassPACF[P <: js.Object, F <: js.Object] = GenericComponentPACF[P, ?, F]
-  given Conversion[ClassPACF[?, ?], VdomNode] = _.render.vdomElement
-
-  type ClassP[P <: js.Object] = GenericComponentP[P]
-  given Conversion[ClassP[?], UndefOr[VdomNode]] = _.render.vdomElement
-  given Conversion[ClassP[?], VdomNode]          = _.render.vdomElement
-
-  type FnP[P <: js.Object] = GenericFnComponentP[P]
-  given Conversion[FnP[?], VdomNode] = _.render
+  // Render typeclass
+  extension [A: Render](self: A) inline def renderVdom: VdomNode = Render[A].renderVdom(self)
 
 object render extends render

--- a/modules/ui/src/main/scala/lucuma/ui/utils/Render.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/utils/Render.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.utils
+
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.syntax.display.given
+import lucuma.core.util.Display
+
+trait Render[A]:
+  def renderVdom(value: A): VdomNode
+
+object Render:
+  def apply[A: Render]: Render[A] = summon[Render[A]]
+
+  def by[A](f: A => VdomNode): Render[A] =
+    new Render:
+      def renderVdom(value: A) = f(value)
+
+  def byShortName[A: Display]: Render[A] = by(_.shortName)
+
+  def byLongName[A: Display]: Render[A] = by(_.longName)


### PR DESCRIPTION
Introduces the `Render` typeclass. Just like `Display`, but allows to display as VDOM. This allows us to define standard visualization of objects that include styling, icons, etc.

Also, port extension methods from explore to render `Pot`s.