### PR TITLE
Remove CanSave state

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/table/TableHooks.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/TableHooks.scala
@@ -28,32 +28,25 @@ private object TableHooks:
   private object PrefsLoaded extends NewType[Boolean]
   private type PrefsLoaded = PrefsLoaded.Type
 
-  private object CanSave extends NewType[Boolean]
-  private type CanSave = CanSave.Type
-
   private def hook[T] =
     CustomHook[TableOptionsWithStateStore[DefaultA, T]]
       .useReactTableBy(_.tableOptions)
       .useState(PrefsLoaded(false))
-      .useRef(CanSave(false))
-      .useEffectOnMountBy((props, table, prefsLoadad, canSave) =>
+      .useEffectOnMountBy((props, table, prefsLoadad) =>
         (props.stateStore.load() >>=
           (mod => table.modState(mod).to[DefaultA]))
           .guarantee( // This also forces a rerender, which react-table isn't doing by just changing the state.
             prefsLoadad.setStateAsync(PrefsLoaded(true))
           )
       )
-      .useEffectWithDepsBy((_, table, _, _) => table.getState())((props, _, prefsLoadad, canSave) =>
+      .useEffectWithDepsBy((_, table, _) => table.getState())((props, _, prefsLoadad) =>
         state =>
           // Don't save prefs while we are still attempting to load them or if we just loaded them.
           props.stateStore
             .save(state)
-            .whenA(prefsLoadad.value.value && canSave.value.value)
-            >> canSave
-              .setAsync(CanSave(true))
-              .whenA(prefsLoadad.value.value && !canSave.value.value)
+            .whenA(prefsLoadad.value.value)
       )
-      .buildReturning((_, table, _, _) => table)
+      .buildReturning((_, table, _) => table)
 
   sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]):
     final def useReactTableWithStateStore[T](


### PR DESCRIPTION
I tracked a bug where the table state is not always stored, and in fact it always fails the first time due to the `CanSave` parameter.
I'm not sure what was the original intent but I think it is not needed