### PR TITLE
useDynTable hook and organize table hooks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion       := "0.77"
+ThisBuild / tlBaseVersion       := "0.78"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 lazy val reactJS = "17.0.2"

--- a/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
@@ -25,6 +25,7 @@ import lucuma.core.util.NewType
 import lucuma.core.util.Timestamp
 import lucuma.core.util.WithGid
 import lucuma.core.util.WithUid
+import lucuma.react.SizePx
 import lucuma.react.common.Size
 import lucuma.react.table.*
 import lucuma.ui.sequence.SequenceRow
@@ -140,6 +141,7 @@ trait ModelReusabiltyInstances
   given Reusability[Proposal]                                = Reusability.byEq
 
 trait TableReusabilityInstances:
+  given Reusability[SizePx]                    = Reusability.by(_.value)
   given Reusability[ColumnId]                  = Reusability.by(_.value)
   given Reusability[Visibility]                = Reusability.by(_.value)
   given Reusability[Map[ColumnId, Visibility]] = Reusability.map

--- a/modules/ui/src/main/scala/lucuma/ui/table/hooks/DynTable.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/hooks/DynTable.scala
@@ -1,0 +1,180 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table.hooks
+
+import cats.syntax.all.*
+import lucuma.react.SizePx
+import lucuma.react.table.*
+import lucuma.ui.table.ColumnSize.*
+import lucuma.ui.table.*
+import monocle.Focus
+import monocle.Lens
+
+import scala.annotation.tailrec
+
+/**
+ * Definition of a dynamic table to be passed to `useDynTable`. Avoid creating in the hook call,
+ * since it performs coherence checks upon creation. Pass a static instance to the hook instead.
+ *
+ * @param columnSizes
+ *   Size definitions for all the columns in the table.
+ * @param columnPriorities
+ *   The order in which columns are removed by overflow. The ones at the beginning are removed
+ *   first. Missing columns are not removed by overflow.
+ * @param initialState
+ */
+case class DynTable(
+  columnSizes:      Map[ColumnId, ColumnSize],
+  columnPriorities: List[ColumnId],
+  initialState:     DynTable.ColState
+):
+  // Check columns comply with the ones passed in columnSizes
+  columnPriorities.foreach(colId =>
+    assert(
+      columnSizes.keySet.contains(colId),
+      s"DynTable.initialState.columnPriorities contains unknown column [$colId] not in columnSizes"
+    )
+  )
+  initialState.resized.value.keySet.foreach(colId =>
+    assert(
+      columnSizes.keySet.contains(colId),
+      s"DynTable.initialState.resized contains unknown column [$colId] not in columnSizes"
+    )
+  )
+  initialState.visibility.value.keySet.foreach(colId =>
+    assert(
+      columnSizes.keySet.contains(colId),
+      s"DynTable.initialState.visibility contains unknown column [$colId] not in columnSizes"
+    )
+  )
+  initialState.overflow.foreach(colId =>
+    assert(
+      columnSizes.keySet.contains(colId),
+      s"DynTable.initialState.overflow contains unknown column [$colId] not in columnSizes"
+    )
+  )
+
+  // This method:
+  // - Adjusts resizable columns proportionally to available space (taking into account space taken by fixed columns).
+  // - If all visible columns are at their minimum width and overflow the viewport,
+  //     then starts dropping columns (as long as there are reamining droppable ones).
+  def adjustColSizes(width: SizePx)(colState: DynTable.ColState): DynTable.ColState = {
+    // Recurse at go1 when a column is dropped.
+    // This level just to avoid clearing overflow on co-recursion
+    @tailrec
+    def go1(colState: DynTable.ColState): DynTable.ColState =
+      lazy val visible: Set[ColumnId] =
+        columnSizes.keySet.filterNot(colId =>
+          colState.visibility.value.get(colId).contains(Visibility.Hidden)
+        ) -- colState.overflow
+
+      lazy val visibleSizes: Map[ColumnId, SizePx] =
+        visible
+          .map: colId =>
+            colId -> colState.resized.value.getOrElse(colId, columnSizes(colId).initial)
+          .toMap
+
+      lazy val prioritizedRemainingCols: List[ColumnId] =
+        columnPriorities.filter(visible.contains)
+
+      lazy val overflowColumn: DynTable.ColState =
+        DynTable.ColState.overflow.modify(_ ++ prioritizedRemainingCols.headOption)(colState)
+
+      if (width.value == 0) colState
+      else {
+        // Recurse at go2 when a column was shrunk/expanded beyond its bounds.
+        @tailrec
+        def go2(
+          remainingCols:  Map[ColumnId, SizePx],
+          fixedAccum:     Map[ColumnId, SizePx] = Map.empty,
+          fixedSizeAccum: Int = 0
+        ): DynTable.ColState = {
+          val (boundedCols, unboundedCols)
+            : (Iterable[(Option[ColumnId], SizePx)], Iterable[(ColumnId, SizePx)]) =
+            remainingCols.partitionMap: (colId, colSize) =>
+              columnSizes(colId) match
+                case FixedSize(size)                                         =>
+                  (none -> size).asLeft
+                // Columns that reach or go beyond their bounds are treated as fixed.
+                case Resizable(_, Some(min), _) if colSize.value < min.value =>
+                  (colId.some -> min).asLeft
+                case Resizable(_, _, Some(max)) if colSize.value > max.value =>
+                  (colId.some -> max).asLeft
+                case _                                                       =>
+                  (colId -> colSize).asRight
+
+          val boundedColsWidth: Int = boundedCols.map(_._2.value).sum
+          val totalBounded: Int     = fixedSizeAccum + boundedColsWidth
+
+          // If bounded columns are more than the viewport width, drop the lowest priority column and start again.
+          if (totalBounded > width.value && prioritizedRemainingCols.nonEmpty)
+            // We must remove columns one by one, since removing one causes the resto to recompute.
+            go1(overflowColumn)
+          else
+            val remainingSpace: Int = width.value - totalBounded
+
+            val totalNewUnbounded: Int = unboundedCols.map(_._2.value).sum
+
+            val ratio: Double = remainingSpace.toDouble / totalNewUnbounded
+
+            val newFixedAccum: Map[ColumnId, SizePx] =
+              fixedAccum ++
+                boundedCols.collect:
+                  case (Some(colId), size) => colId -> size
+
+            val unboundedColsAdjusted: Map[ColumnId, SizePx] =
+              unboundedCols
+                .map: (colId, width) =>
+                  colId -> width.modify(x => (x * ratio).toInt)
+                .toMap
+
+            boundedCols match
+              case Nil        =>
+                DynTable.ColState.resized.replace(
+                  ColumnSizing(newFixedAccum ++ unboundedColsAdjusted)
+                )(colState)
+              case newBounded =>
+                go2(unboundedColsAdjusted, newFixedAccum, totalBounded)
+        }
+
+        go2(visibleSizes)
+      }
+
+    go1(colState.resetOverflow)
+  }
+
+object DynTable:
+  /**
+   * State of the columns in a dynamic table.
+   *
+   * @param resized
+   *   Resized columns. To be passed directly to table `state` as `PartialTableState.columnSizing`.
+   * @param visibility
+   *   Column visitibility without taking into account overflows. Do not pass to table. See
+   *   `computedVisibility` instead.
+   * @param overflow
+   *   Column overflows.
+   */
+  case class ColState(
+    val resized:    ColumnSizing,
+    val visibility: ColumnVisibility,
+    val overflow:   Set[ColumnId] = Set.empty
+  ):
+    /**
+     * Column visitibility. To be passed directly to table `state` as
+     * `PartialTableState.columnVisibility`.
+     */
+    lazy val computedVisibility: ColumnVisibility =
+      visibility.modify(_ ++ overflow.map(_ -> Visibility.Hidden))
+
+    /**
+     * The same state without overflows. Useful when recomputing them.
+     */
+    def resetOverflow: ColState =
+      ColState.overflow.replace(Set.empty)(this)
+
+  object ColState:
+    val resized: Lens[ColState, ColumnSizing]        = Focus[ColState](_.resized)
+    val visibility: Lens[ColState, ColumnVisibility] = Focus[ColState](_.visibility)
+    val overflow: Lens[ColState, Set[ColumnId]]      = Focus[ColState](_.overflow)

--- a/modules/ui/src/main/scala/lucuma/ui/table/hooks/TableStateStore.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/hooks/TableStateStore.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.ui.table
+package lucuma.ui.table.hooks
 
 import cats.Endo
 import lucuma.react.table.TableState

--- a/modules/ui/src/main/scala/lucuma/ui/table/hooks/UseDynTable.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/hooks/UseDynTable.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table.hooks
+
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.hooks.CustomHook
+import lucuma.react.SizePx
+import lucuma.react.table.*
+import lucuma.ui.reusability.given
+
+/**
+ * Provides values to be passed to the table definition:
+ *   - `columnSizing`: To be passed directly to table `state` as `PartialTableState.columnSizing`.
+ *   - `columnVisibility`: To be passed directly to table `state` as
+ *     `PartialTableState.columnVisibility`.
+ *   - `onColumnSizingChangeHandler`: To be passed directly to table `onColumnSizingChange`.
+ */
+class UseDynTable(
+  colState:                        DynTable.ColState,
+  val onColumnSizingChangeHandler: Updater[ColumnSizing] => Callback
+):
+  export colState.{computedVisibility => columnVisibility, resized => columnSizing}
+
+object UseDynTable:
+  private val hook = CustomHook[(DynTable, SizePx)] // (dynTable, width)
+    .useStateBy(_._1.initialState) // colState
+    .useEffectWithDepsBy((props, _) => // Recompute columns upon resize
+      props._2
+    )((props, colState) => width => colState.modState(s => props._1.adjustColSizes(width)(s)))
+    .buildReturning: (props, colState) =>
+      val (dynTable, width) = props
+
+      val onColumnSizingChangeHandler: Updater[ColumnSizing] => Callback =
+        (_: Updater[ColumnSizing]) match
+          case Updater.Set(v)  =>
+            colState.modState: s =>
+              dynTable.adjustColSizes(width)(DynTable.ColState.resized.replace(v)(s))
+          case Updater.Mod(fn) =>
+            colState.modState: s =>
+              dynTable.adjustColSizes(width)(DynTable.ColState.resized.modify(fn)(s))
+
+      UseDynTable(colState.value, onColumnSizingChangeHandler)
+
+  object HooksApiExt:
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]):
+      /**
+       * Computes a dynamic table state, automatically computing column overflows and sizes.
+       *
+       * @param dynTable
+       *   Dynamic table definition.
+       * @param width
+       *   Table width in pixels.
+       */
+      final def useDynTable(dynTable: DynTable, width: SizePx)(using
+        step: Step
+      ): step.Next[UseDynTable] =
+        useDynTableBy(_ => (dynTable, width))
+
+      /**
+       * Computes a dynamic table state, automatically computing column overflows and sizes.
+       *
+       * @param dynTable
+       *   Dynamic table definition.
+       * @param width
+       *   Table width in pixels.
+       */
+      final def useDynTableBy(props: Ctx => (DynTable, SizePx))(using
+        step: Step
+      ): step.Next[UseDynTable] =
+        api.customBy(ctx => hook(props(ctx)))
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api):
+      /**
+       * Computes a dynamic table state, automatically computing column overflows and sizes.
+       *
+       * @param dynTable
+       *   Dynamic table definition.
+       * @param width
+       *   Table width in pixels.
+       */
+      def useDynTableBy(props: CtxFn[(DynTable, SizePx)])(using
+        step: Step
+      ): step.Next[UseDynTable] =
+        useDynTableBy(step.squash(props)(_))
+
+  protected trait HooksApiExt:
+    import HooksApiExt.*
+
+    implicit def hooksExtDynTable1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtDynTable2[
+      Ctx,
+      CtxFn[_],
+      Step <: HooksApi.SubsequentStep[Ctx, CtxFn]
+    ](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+
+  object syntax extends HooksApiExt

--- a/modules/ui/src/main/scala/lucuma/ui/table/hooks/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/hooks/package.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table.hooks
+
+export UseDynTable.syntax.*, UseReactTableWithStateStore.syntax.*


### PR DESCRIPTION
Defines a `useDynTable` hooks that helps in maintaining columns when we have a table with both fixed and variable column widths. If the table width changes or a column width changes, it resizes variable width columns proportionally, while respecting their min and max sizes. It also adds the option to drop columns when they don't fit (instead of adding scroll bars).

Unifies with previously defined table hook so that their usage is similar to other hooks (via import instead of extending a trait).


![Kapture 2023-08-13 at 19 50 19](https://github.com/gemini-hlsw/lucuma-ui/assets/1895643/e04eaa9c-a2d1-45d4-94d3-4d7d8ff46b8c)

