### PR TITLE
Better handling of theme reinitialization

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/enums/Theme.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/enums/Theme.scala
@@ -79,11 +79,9 @@ object Theme:
         else if (isLight) Theme.Light
         else Theme.Dark
 
-  def init(default: Theme = Theme.System): DefaultS[Unit] =
-    currentClasses.flatMap:
-      _.fold(mountListener >> default.mount)(_ =>
-        DefaultS.throwException(new Exception("Theme already initialized"))
-      )
+  def init(default: Theme = Theme.System): DefaultS[Theme] =
+    current.flatMap:
+      _.fold(mountListener >> default.mount.as(default))(DefaultS.pure(_))
 
   given Display[Theme] = Display.byShortName(_.name)
 

--- a/modules/ui/src/main/scala/lucuma/ui/hooks/UseTheme.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/hooks/UseTheme.scala
@@ -13,15 +13,13 @@ private object UseTheme:
   private val hook =
     CustomHook[Theme]
       .useStateViewBy(initial => initial)
-      .useEffectOnMountBy((initial, _) => Theme.init(initial))
+      .useEffectOnMountBy((initial, state) => Theme.init(initial) >>= state.set)
       .buildReturning((_, theme) => theme.withOnMod(_.mount))
 
   object HooksApiExt:
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]):
       /**
        * Applies theming to the whole page and provides a `View` to change the theme.
-       *
-       * WARNING: Do not call more than once in the whole page. This will result in an error.
        *
        * @param initial
        *   Initial theme. Defaults to `Theme.System`.
@@ -31,8 +29,6 @@ private object UseTheme:
 
       /**
        * Applies theming to the whole page and provides a `View` to change the theme.
-       *
-       * WARNING: Do not call more than once in the whole page. This will result in an error.
        *
        * @param initial
        *   Initial theme. Defaults to `Theme.System`.
@@ -45,8 +41,6 @@ private object UseTheme:
     ) extends Primary[Ctx, Step](api):
       /**
        * Applies theming to the whole page and provides a `View` to change the theme.
-       *
-       * WARNING: Do not call more than once in the whole page. This will result in an error.
        *
        * @param initial
        *   Initial theme. Defaults to `Theme.System`.


### PR DESCRIPTION
Throwing an error on theme reinitialization failed on hot reload. This changes the logic so that reinitialization is not performed and gets the current theme instead.