### PR TITLE
Add the css from DataTable that we are using in PrimeTable

### DIFF
--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
@@ -4,6 +4,8 @@
       border-collapse: collapse;
       border-spacing: 0;
       table-layout: fixed;
+      position: relative;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
Primereact has changed the way they provide non-theme CSS for their components. It is now added to the docoment head programatically when a component is loaded. The old `primereact.css` file is now empty. This affects us because `PrimeTable` uses the primereact CSS classes. Since we don't use the `DataTable` component, which would provide the CSS, we miss out on a couple of layout bits for PrimeTable.

I wasted a bunch of time trying to see if I could load the CSS from the `DataTable` component, but the relevant bits aren't exported from the components. So, I checked to see which of the primereact classes we are using, and cross-checked that with the CSS in the `DataTable` component. It turns out all we are missing is the 2 bits of CSS in this PR. 