### PR TITLE
Add CSS for putting a Message in the MainBody

### DIFF
--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-layout.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-layout.scss
@@ -42,6 +42,17 @@
   overflow: hidden;
   display: grid;
   justify-items: stretch;
+
+  &.with-message {
+    overflow: unset;
+    grid-template-rows: 1fr max-content;
+
+    // The second child should be a PrimeReact `Message`, although other 
+    // things might work.
+    div:first-child {
+      overflow: auto;
+    }
+  }
 }
 
 .main-title {

--- a/modules/ui/src/main/scala/lucuma/ui/layout/LayoutStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/layout/LayoutStyles.scala
@@ -11,3 +11,6 @@ object LayoutStyles:
   val MainBody: Css     = Css("main-body")
   val MainTitle: Css    = Css("main-title")
   val MainUserName: Css = Css("main-user-name")
+
+  // used with MainBody to display a `Message` below the rest of the MainBody
+  val WithMessage: Css = Css("with-message")


### PR DESCRIPTION
I'm using this to display a Message at the bottom of the MainBody when the proposal has been submitted so users will know why it is readonly. If this does not seem generally useful, I could keep it in Explore.