### PR TITLE
Rework sequence tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,28 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.94"
+ThisBuild / tlBaseVersion       := "0.95"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
-lazy val catsVersion              = "2.10.0"
-lazy val catsRetryVersion         = "3.1.3"
-lazy val circeVersion             = "0.14.6"
-lazy val crystalVersion           = "0.37.3"
-lazy val fs2DomVersion            = "0.3.0-M1"
-lazy val kittensVersion           = "3.3.0"
-lazy val http4sVersion            = "0.23.26"
-lazy val http4sDomVersion         = "0.2.11"
-lazy val lucumaCoreVersion        = "0.94.1"
-lazy val lucumaPrimeStylesVersion = "0.2.10"
-lazy val lucumaReactVersion       = "0.53.0"
-lazy val lucumaRefinedVersion     = "0.1.2"
-lazy val lucumaSchemasVersion     = "0.77.2"
-lazy val lucumaSsoVersion         = "0.6.14"
-lazy val monocleVersion           = "3.2.0"
-lazy val mouseVersion             = "1.2.3"
-lazy val pprintVersion            = "0.8.1"
-lazy val scalaJsReactVersion      = "3.0.0-beta3"
+val Versions = new {
+  val cats              = "2.10.0"
+  val catsRetry         = "3.1.3"
+  val circe             = "0.14.6"
+  val crystal           = "0.37.3"
+  val fs2Dom            = "0.3.0-M1"
+  val kittens           = "3.3.0"
+  val http4s            = "0.23.26"
+  val http4sDom         = "0.2.11"
+  val lucumaCore        = "0.94.1"
+  val lucumaPrimeStyles = "0.2.10"
+  val lucumaReact       = "0.55.0"
+  val lucumaRefined     = "0.1.2"
+  val lucumaSchemas     = "0.77.2"
+  val lucumaSso         = "0.6.14"
+  val monocle           = "3.2.0"
+  val mouse             = "1.2.3"
+  val pprint            = "0.8.1"
+  val scalaJsReact      = "3.0.0-beta3"
+}
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
@@ -61,7 +63,7 @@ lazy val demo =
         ModuleSplitStyle.SmallestModules
       )),
       libraryDependencies ++= Seq(
-        "com.github.japgolly.scalajs-react" %%% "callback-ext-cats_effect" % scalaJsReactVersion
+        "com.github.japgolly.scalajs-react" %%% "callback-ext-cats_effect" % Versions.scalaJsReact
       ),
       Keys.test := {}
     )
@@ -73,33 +75,32 @@ lazy val ui =
     .settings(
       name := "lucuma-ui",
       libraryDependencies ++= Seq(
-        "org.typelevel"                     %%% "cats-core"                    % catsVersion,
-        "org.typelevel"                     %%% "kittens"                      % kittensVersion,
-        "org.typelevel"                     %%% "mouse"                        % mouseVersion,
-        "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io"            % scalaJsReactVersion,
-        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3"           % scalaJsReactVersion,
-        "edu.gemini"                        %%% "lucuma-core"                  % lucumaCoreVersion,
-        "edu.gemini"                        %%% "lucuma-react-common"          % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-clipboard"       % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-font-awesome"    % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-resize-detector" % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-tanstack-table"  % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-floatingui"      % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-react-prime-react"     % lucumaReactVersion,
-        "edu.gemini"                        %%% "lucuma-prime-styles"          % lucumaPrimeStylesVersion,
-        "edu.gemini"                        %%% "lucuma-schemas"               % lucumaSchemasVersion,
-        "dev.optics"                        %%% "monocle-core"                 % monocleVersion,
-        "dev.optics"                        %%% "monocle-macro"                % monocleVersion,
-        "edu.gemini"                        %%% "crystal"                      % crystalVersion,
-        "com.lihaoyi"                       %%% "pprint"                       % pprintVersion,
-        "com.armanbilge"                    %%% "fs2-dom"                      % fs2DomVersion,
-        "org.http4s"                        %%% "http4s-core"                  % http4sVersion,
-        "org.http4s"                        %%% "http4s-circe"                 % http4sVersion,
-        "org.http4s"                        %%% "http4s-dom"                   % http4sDomVersion,
-        "com.github.cb372"                  %%% "cats-retry"                   % catsRetryVersion,
-        "io.circe"                          %%% "circe-core"                   % circeVersion,
-        "io.circe"                          %%% "circe-parser"                 % circeVersion,
-        "edu.gemini"                        %%% "lucuma-sso-frontend-client"   % lucumaSsoVersion
+        "org.typelevel"                     %%% "cats-core"                    % Versions.cats,
+        "org.typelevel"                     %%% "kittens"                      % Versions.kittens,
+        "org.typelevel"                     %%% "mouse"                        % Versions.mouse,
+        "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io"            % Versions.scalaJsReact,
+        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3"           % Versions.scalaJsReact,
+        "edu.gemini"                        %%% "lucuma-core"                  % Versions.lucumaCore,
+        "edu.gemini"                        %%% "lucuma-react-common"          % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-react-font-awesome"    % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-react-resize-detector" % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-react-tanstack-table"  % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-react-floatingui"      % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-react-prime-react"     % Versions.lucumaReact,
+        "edu.gemini"                        %%% "lucuma-prime-styles"          % Versions.lucumaPrimeStyles,
+        "edu.gemini"                        %%% "lucuma-schemas"               % Versions.lucumaSchemas,
+        "dev.optics"                        %%% "monocle-core"                 % Versions.monocle,
+        "dev.optics"                        %%% "monocle-macro"                % Versions.monocle,
+        "edu.gemini"                        %%% "crystal"                      % Versions.crystal,
+        "com.lihaoyi"                       %%% "pprint"                       % Versions.pprint,
+        "com.armanbilge"                    %%% "fs2-dom"                      % Versions.fs2Dom,
+        "org.http4s"                        %%% "http4s-core"                  % Versions.http4s,
+        "org.http4s"                        %%% "http4s-circe"                 % Versions.http4s,
+        "org.http4s"                        %%% "http4s-dom"                   % Versions.http4sDom,
+        "com.github.cb372"                  %%% "cats-retry"                   % Versions.catsRetry,
+        "io.circe"                          %%% "circe-core"                   % Versions.circe,
+        "io.circe"                          %%% "circe-parser"                 % Versions.circe,
+        "edu.gemini"                        %%% "lucuma-sso-frontend-client"   % Versions.lucumaSso
       )
     )
 
@@ -111,7 +112,7 @@ lazy val testkit =
     .settings(
       name := "lucuma-ui-testkit",
       libraryDependencies ++= Seq(
-        "edu.gemini" %%% "lucuma-core-testkit" % lucumaCoreVersion
+        "edu.gemini" %%% "lucuma-core-testkit" % Versions.lucumaCore
       )
     )
 
@@ -121,10 +122,10 @@ lazy val tests =
     .dependsOn(testkit)
     .settings(
       libraryDependencies ++= Seq(
-        "edu.gemini"    %%% "lucuma-core-testkit"    % lucumaCoreVersion    % Test,
-        "edu.gemini"    %%% "lucuma-schemas-testkit" % lucumaSchemasVersion % Test,
-        "org.scalameta" %%% "munit"                  % "0.7.29"             % Test,
-        "org.typelevel" %%% "discipline-munit"       % "1.0.9"              % Test
+        "edu.gemini"    %%% "lucuma-core-testkit"    % Versions.lucumaCore    % Test,
+        "edu.gemini"    %%% "lucuma-schemas-testkit" % Versions.lucumaSchemas % Test,
+        "org.scalameta" %%% "munit"                  % "0.7.29"               % Test,
+        "org.typelevel" %%% "discipline-munit"       % "1.0.9"                % Test
       )
     )
     .enablePlugins(ScalaJSPlugin, NoPublishPlugin)
@@ -145,7 +146,7 @@ lazy val css = project
         cssDir / "package.json",
         s"""|{
             |  "name": "lucuma-ui-css",
-            |  "version": "${version.value}",
+            |  "": "${version.value}",
             |  "license": "${licenses.value.head._1}"
             |}
             |""".stripMargin

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-common.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-common.scss
@@ -17,3 +17,15 @@ a,
 a:hover {
   text-decoration: none;
 }
+
+.lucuma-indicator-ok {
+  color: var(--green-400);
+}
+
+.lucuma-indicator-warning {
+  color: var(--yellow-500);
+}
+
+.lucuma-indicator-fail {
+  color: var(--red-500);
+}

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
@@ -92,7 +92,8 @@ table tr .lucuma-visit-step-extra {
   }
 
   .lucuma-visit-step-extra-datasets {
-    width: 75%;
+    flex-grow: 1;
+    text-align: left;
 
     .lucuma-visit-step-extra-dataset-item {
       margin-right: 2.5dvw;

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
@@ -2,6 +2,8 @@
 // Sequence tables
 // ------
 
+@use "lucuma-ui-common.scss" as lucumaUICommon;
+
 .pl-react-table.p-datatable.lucuma-sequence-table {
   .p-datatable-thead > tr > th {
     text-align: center;
@@ -41,4 +43,67 @@
 
 .lucuma-sequence-step-type-dark {
   color: var(--gray-900);
+}
+
+.lucuma-table-header {
+  display: flex;
+
+  &.lucuma-table-header-expandable {
+    cursor: pointer;
+  }
+
+  .lucuma-table-header-content {
+    flex-grow: 1;
+    padding: 0 10px;
+  }
+}
+
+.lucuma-visit-header {
+  display: flex;
+  justify-content: space-between;
+  color: var(--gray-600);
+
+  span {
+    @include lucumaUICommon.text-ellipsis;
+
+    &:first-child {
+      text-align: left;
+    }
+
+    &:not(:last-child) {
+      width: 23%;
+    }
+
+    &:last-child {
+      width: 8%;
+      text-align: right;
+    }
+  }
+}
+
+table tr .lucuma-visit-step-extra {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding-left: 5%;
+
+  .lucuma-visit-step-extra-datetime {
+    width: 20%;
+  }
+
+  .lucuma-visit-step-extra-datasets {
+    width: 75%;
+
+    .lucuma-visit-step-extra-dataset-item {
+      margin-right: 2.5dvw;
+
+      .lucuma-visit-step-extra-dataset-status-icon {
+        padding-left: 0.5dvw;
+      }
+
+      .lucuma-visit-step-extra-dataset-status-label {
+        padding-left: 0.2dvw;
+      }
+    }
+  }
 }

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
@@ -10,13 +10,13 @@
   }
 
   // Cell
-  .p-datatable-thead>tr>th {
+  .p-datatable-thead > tr > th {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .p-datatable-tbody>tr>td {
+  .p-datatable-tbody > tr > td {
     padding: 6px;
     white-space: nowrap;
     overflow: hidden;
@@ -54,29 +54,31 @@
 
   // Compact
   &.pl-compact {
-    .p-datatable-thead>tr>th {
+    .p-datatable-thead > tr > th {
       padding: 0.25em 0.25em;
     }
 
-    .p-datatable-tbody>tr>td {
+    .p-datatable-tbody > tr > td {
       padding: 0.5em 0.25em;
     }
   }
 
   &.pl-very-compact {
-    .p-datatable-thead>tr>th {
+    .p-datatable-thead > tr > th {
       padding: 0.25em 0.6em;
     }
 
-    .p-datatable-tbody>tr>td {
+    .p-datatable-tbody > tr > td {
       padding: 0.4em 0.6em;
     }
   }
 
   // Hoverable-rows
   &.p-datatable.p-datatable-hoverable-rows {
-    .p-datatable-tbody>tr:not(.p-highlight):not(.p-datatable-emptymessage):not(.is-subcomponent) {
-
+    .p-datatable-tbody
+      > tr:not(.p-highlight):not(.p-datatable-emptymessage):not(
+        .is-subcomponent
+      ) {
       // Hover on this row, or in the next one if this one has subcomponent.
       &:hover,
       &.has-subcomponent:has(+ :hover) {
@@ -84,13 +86,14 @@
         background-color: var(--surface-100);
 
         &:not(.has-subcomponent) {
-          box-shadow: inset 0 1px 0 0 var(--green-500), inset 0 -1px 0 0 var(--green-500);
+          box-shadow: inset 0 1px 0 0 var(--green-500),
+            inset 0 -1px 0 0 var(--green-500);
         }
 
         &.has-subcomponent {
           box-shadow: inset 0 1px 0 0 var(--green-500);
 
-          &+tr {
+          & + tr {
             position: relative;
             background-color: var(--surface-100);
             box-shadow: inset 0 -1px 0 0 var(--green-500);
@@ -102,13 +105,13 @@
 
   // Celled
   &.pl-celled-table {
-    .p-datatable-tbody>tr>td:not(:first-of-type) {
+    .p-datatable-tbody > tr > td:not(:first-of-type) {
       border-left-width: 1px;
     }
   }
 
   // Striped
-  &.pl-striped-table>.p-datatable-tbody>tr.row-even {
+  &.pl-striped-table > .p-datatable-tbody > tr.row-even {
     background-color: var(--surface-50);
   }
 
@@ -167,8 +170,22 @@
       opacity: 0;
     }
 
-    thead:not(.pl-head-resizing) *:hover>.pl-resizer {
+    thead:not(.pl-head-resizing) *:hover > .pl-resizer {
       opacity: 1;
     }
+  }
+
+  .expander-chevron {
+    &:hover {
+      color: var(--site-link-color);
+    }
+
+    svg {
+      transition: transform 0.1s ease-in;
+    }
+  }
+
+  .expander-chevron-open svg {
+    transform: rotate(90deg);
   }
 }

--- a/modules/ui/src/main/scala/lucuma/ui/LucumaStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/LucumaStyles.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui
+
+import lucuma.react.common.Css
+
+object LucumaStyles:
+  val IndicatorOK: Css      = Css("lucuma-indicator-ok")
+  val IndicatorWarning: Css = Css("lucuma-indicator-warning")
+  val IndicatorFail: Css    = Css("lucuma-indicator-fail")

--- a/modules/ui/src/main/scala/lucuma/ui/display/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/display/package.scala
@@ -1,22 +1,53 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.ui
+package lucuma.ui.display
 
+import lucuma.core.enums.*
+import lucuma.core.enums.Site
 import lucuma.core.util.Display
 
 import java.util.concurrent.TimeUnit
 
-package object display:
-  given Display[TimeUnit] = Display.by(
-    {
-      case TimeUnit.NANOSECONDS  => "ns"
-      case TimeUnit.MICROSECONDS => "µs"
-      case TimeUnit.MILLISECONDS => "ms"
-      case TimeUnit.SECONDS      => "s"
-      case TimeUnit.MINUTES      => "m"
-      case TimeUnit.HOURS        => "h"
-      case TimeUnit.DAYS         => "d"
-    },
-    _.toString.toLowerCase()
-  )
+given Display[Site] =
+  Display.byShortName(_.shortName)
+
+given Display[TimeUnit] = Display.by(
+  {
+    case TimeUnit.NANOSECONDS  => "ns"
+    case TimeUnit.MICROSECONDS => "µs"
+    case TimeUnit.MILLISECONDS => "ms"
+    case TimeUnit.SECONDS      => "s"
+    case TimeUnit.MINUTES      => "m"
+    case TimeUnit.HOURS        => "h"
+    case TimeUnit.DAYS         => "d"
+  },
+  _.toString.toLowerCase()
+)
+
+given Display[GmosXBinning] = Display.by(_.shortName, _.longName)
+
+given Display[GmosYBinning] = Display.by(_.shortName, _.longName)
+
+given Display[GmosNorthGrating] = Display.byShortName(_.longName)
+
+given Display[GmosSouthGrating] = Display.byShortName(_.longName)
+
+given Display[GmosNorthFilter] = Display.byShortName(_.longName)
+
+given Display[GmosSouthFilter] = Display.byShortName(_.longName)
+
+given Display[GmosNorthFpu] = Display.byShortName(_.longName)
+
+given Display[GmosSouthFpu] = Display.byShortName(_.longName)
+
+given Display[GmosAmpReadMode] =
+  Display.by(_.shortName, _.longName)
+
+given Display[GmosAmpGain] = Display.by(_.shortName, _.longName)
+
+given Display[GmosRoi] = Display.byShortName(_.longName)
+
+given Display[SequenceType] = Display.byShortName:
+  case SequenceType.Acquisition => "Acquisition"
+  case SequenceType.Science     => "Science"

--- a/modules/ui/src/main/scala/lucuma/ui/format/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/format/package.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.format
+
+import cats.syntax.all.*
+
+import java.time.Duration
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+val GppDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd")
+
+val GppTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+val GppTimeTZFormatter: DateTimeFormatter =
+  DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneOffset.UTC)
+
+val GppTimeTZFormatterWithZone: DateTimeFormatter =
+  DateTimeFormatter.ofPattern("HH:mm 'UTC'").withZone(ZoneOffset.UTC)
+
+val IsoUTCFormatter: DateTimeFormatter =
+  DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC)
+
+val UtcFormatter: DateTimeFormatter =
+  DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC)
+
+val DurationFormatter: Duration => String = d =>
+  val hours: Option[Long]  = d.toHours.some.filter(_ > 0)
+  val minutes: Option[Int] = d.toMinutesPart.some.filter(_ > 0 || hours.isDefined)
+  val seconds: Int         = d.toSecondsPart
+  hours.map(h => s"${h}h").orEmpty + minutes.map(m => s"${m}m").orEmpty + s"${seconds}s"
+
+val DurationLongFormatter: Duration => String = d =>
+  val days: Option[Long]   = d.toDays.some.filter(_ > 0)
+  val hours: Option[Int]   = d.toHoursPart.some.filter(_ > 0)
+  val minutes: Option[Int] = d.toMinutesPart.some.filter(_ > 0 || (days.isEmpty && hours.isEmpty))
+  List(days, hours, minutes)
+    .zip(List("day", "hour", "minute"))
+    .map((nOpt, units) => nOpt.map(n => s"$n $units" + (if (n != 1) "s" else "")))
+    .flattenOption
+    .mkString(", ")

--- a/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
@@ -30,6 +30,7 @@ import lucuma.core.util.WithUid
 import lucuma.react.SizePx
 import lucuma.react.common.Size
 import lucuma.react.table.*
+import lucuma.schemas.model.Visit
 import lucuma.ui.sequence.SequenceRow
 import lucuma.ui.sso.UserVault
 
@@ -143,6 +144,7 @@ trait ModelReusabiltyInstances
   given Reusability[ProposalClass]                           = Reusability.byEq
   given Reusability[Proposal]                                = Reusability.byEq
   given Reusability[InstrumentExecutionConfig]               = Reusability.byEq
+  given [D: Eq]: Reusability[Visit[D]]                       = Reusability.byEq
 
 trait TableReusabilityInstances:
   given Reusability[SizePx]                    = Reusability.by(_.value)
@@ -158,10 +160,7 @@ trait TableReusabilityInstances:
     Reusability.by(state => (state.columnVisibility, state.sorting))
 
 trait SequenceReusabilityInstances:
-  given [D: Eq]: Reusability[SequenceRow[D]]                        = Reusability.byEq
-  given [D: Eq]: Reusability[SequenceRow.FutureStep[D]]             = Reusability.byEq
-  given [D: Eq]: Reusability[SequenceRow.Executed.ExecutedVisit[D]] = Reusability.byEq
-  given [D: Eq]: Reusability[SequenceRow.Executed.ExecutedStep[D]]  = Reusability.byEq
+  given [D]: Reusability[SequenceRow[D]] = Reusability.byEq
 
 package object reusability
     extends UtilReusabilityInstances

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceIcons.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceIcons.scala
@@ -26,10 +26,11 @@ object SequenceIcons:
   // This is tedious but lets us do proper tree-shaking
   FontAwesome.library.add(
     faCircle,
+    faSquare,
     faCrosshairs
   )
 
-  // TODO COlor
+  // TODO Color
   private def letterLayeredIcon(icon: FontAwesomeIcon, letter: Char, clazz: Css): LayeredIcon =
     LayeredIcon(clazz = clazz, fixedWidth = true)(
       icon,

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceStyles.scala
@@ -9,6 +9,18 @@ object SequenceStyles:
   val SequenceTable: Css = Css("lucuma-sequence-table")
   val StepGuided: Css    = Css("lucuma-sequence-step-guided")
 
+  val TableHeader           = Css("lucuma-table-header")
+  val TableHeaderExpandable = Css("lucuma-table-header-expandable")
+  val TableHeaderContent    = Css("lucuma-table-header-content")
+
+  val VisitHeader                      = Css("lucuma-visit-header")
+  val VisitStepExtra                   = Css("lucuma-visit-step-extra")
+  val VisitStepExtraDatetime           = Css("lucuma-visit-step-extra-datetime")
+  val VisitStepExtraDatasets           = Css("lucuma-visit-step-extra-datasets")
+  val VisitStepExtraDatasetItem        = Css("lucuma-visit-step-extra-dataset-item")
+  val VisitStepExtraDatasetStatusIcon  = Css("lucuma-visit-step-extra-dataset-status-icon")
+  val VisitStepExtraDatasetStatusLabel = Css("lucuma-visit-step-extra-dataset-status-label")
+
   object StepType:
     val Bias: Css   = Css("lucuma-sequence-step-type-bias")
     val Dark: Css   = Css("lucuma-sequence-step-type-dark")

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/package.scala
@@ -17,7 +17,8 @@ import lucuma.react.floatingui.syntax.*
 import lucuma.ui.utils.*
 import lucuma.ui.utils.Render
 
-object StepIndex extends NewType[PosInt]
+object StepIndex extends NewType[PosInt]:
+  val One: StepIndex = StepIndex(PosInt.unsafeFrom(1))
 type StepIndex = StepIndex.Type
 
 private def renderStepType(icon: VdomNode, tooltip: String): VdomNode =
@@ -36,8 +37,13 @@ given Render[StepTypeDisplay] = Render.by: stepType =>
   renderStepType(stepType.icon, stepType.name)
 
 extension [D, R <: SequenceRow[D]](list: List[R])
-  def zipWithStepIndex: List[(R, StepIndex)] =
-    list.zipWithMappedIndex(i => StepIndex(PosInt.unsafeFrom(i + 1)))
+  /* Zip list with `StepIndex` and return the indexed list and the next index */
+  def zipWithStepIndex(
+    initial: StepIndex = StepIndex(PosInt.unsafeFrom(1))
+  ): (List[(R, StepIndex)], StepIndex) =
+    (list.zipWithMappedIndex(index => initial.modifyValue(i => PosInt.unsafeFrom(i.value + index))),
+     initial.modifyValue(i => PosInt.unsafeFrom(i.value + list.size))
+    )
 
 extension (sn: Option[SignalToNoise])
   def showForFutureStep[D](r: Step[D]): Option[SignalToNoise] =

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/util.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/util.scala
@@ -6,6 +6,7 @@ package lucuma.ui.syntax
 import cats.Monoid
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.React
+import japgolly.scalajs.react.Reusable
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.EnumValue
 
@@ -19,6 +20,14 @@ trait util:
     val empty: VdomNode = EmptyVdom
     def combine(x: VdomNode, y: VdomNode): VdomNode = React.Fragment(x, y)
 
+  given Monoid[TagMod] = new Monoid[TagMod]:
+    val empty: TagMod = TagMod.empty
+    def combine(x: TagMod, y: TagMod): TagMod = TagMod(x, y)
+
   extension (c: Callback.type) def pprintln[T](a: T): Callback = Callback(_root_.pprint.pprintln(a))
+
+  extension [A](reusableList: Reusable[List[A]])
+    def sequenceList: List[Reusable[A]] =
+      reusableList.value.map(x => reusableList.map(_ => x))
 
 object util extends util

--- a/modules/ui/src/main/scala/lucuma/ui/table/HeaderOrRow.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/HeaderOrRow.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table
+
+import cats.syntax.all.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.table.RowId
+
+type HeaderOrRow[+R] = Either[HeaderRow, R]
+
+case class HeaderRow(rowId: RowId, content: VdomNode):
+  def toHeaderOrRow[R]: HeaderOrRow[R] = this.asLeft
+
+extension [R](row: R) def toHeaderOrRow: HeaderOrRow[R] = row.asRight

--- a/modules/ui/src/main/scala/lucuma/ui/table/TableIcons.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/TableIcons.scala
@@ -10,6 +10,10 @@ import scala.scalajs.js.annotation.*
 
 object TableIcons:
   @js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faChevronRight")
+  val faChevronRight: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faSort")
   val faSort: FAIcon = js.native
 
@@ -23,11 +27,13 @@ object TableIcons:
 
   // This is tedious but lets us do proper tree-shaking
   FontAwesome.library.add(
+    faChevronRight,
     faSort,
     faSortDown,
     faSortUp
   )
 
-  val Sort     = FontAwesomeIcon(faSort)
-  val SortDown = FontAwesomeIcon(faSortDown)
-  val SortUp   = FontAwesomeIcon(faSortUp)
+  val ChevronRight = FontAwesomeIcon(faChevronRight)
+  val Sort         = FontAwesomeIcon(faSort)
+  val SortDown     = FontAwesomeIcon(faSortDown)
+  val SortUp       = FontAwesomeIcon(faSortUp)

--- a/modules/ui/src/main/scala/lucuma/ui/table/TableStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/TableStyles.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table
+
+import lucuma.react.common.Css
+
+object TableStyles:
+  val ExpanderChevron: Css     = Css("expander-chevron")
+  val ExpanderChevronOpen: Css = Css("expander-chevron-open")


### PR DESCRIPTION
A number of changes to the common code in order to build sequence table:
- With visits.
- With expandable sections.
- Virtualized.

Common formatters and `Display` instances have been moved here too.
