### PR TITLE
Unify sequence table logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.95"
+ThisBuild / tlBaseVersion       := "0.96"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-sequence.scss
@@ -7,13 +7,37 @@
 .pl-react-table.p-datatable.lucuma-sequence-table {
   .p-datatable-thead > tr > th {
     text-align: center;
+
+    &.lucuma-sequence-hidden-col-table-header {
+      padding: 0;
+      border: 0;
+    }
   }
 
-  .p-datatable-tbody > tr > td {
-    padding-top: 0;
-    padding-bottom: 0;
-    border-left: 0;
-    text-align: center;
+  .p-datatable-tbody > tr {
+    &:not(.lucuma-sequence-row-has-extra) {
+      height: 25px;
+    }
+
+    &.lucuma-sequence-row-has-extra {
+      height: 60px;
+      vertical-align: top;
+    }
+
+    & > td {
+      padding-top: 0;
+      padding-bottom: 0;
+      border-left: 0;
+      text-align: center;
+
+      &.lucuma-sequence-extra-row-shown {
+        display: inline-block;
+        position: relative;
+        top: 24px;
+        padding: 0;
+        border: 0;
+      }
+    }
   }
 
   .p-datatable-tbody > tr:last-of-type > td {
@@ -45,20 +69,26 @@
   color: var(--gray-900);
 }
 
-.lucuma-table-header {
+.lucuma-sequence-header {
   display: flex;
 
-  &.lucuma-table-header-expandable {
+  &.lucuma-sequence-header-expandable {
     cursor: pointer;
   }
 
-  .lucuma-table-header-content {
+  .lucuma-sequence-header-content {
     flex-grow: 1;
     padding: 0 10px;
+    font-size: 15px;
+    font-weight: bolder;
+
+    .lucuma-sequence-current-header {
+      display: flex;
+    }
   }
 }
 
-.lucuma-visit-header {
+.lucuma-sequence-visit-header {
   display: flex;
   justify-content: space-between;
   color: var(--gray-600);
@@ -81,29 +111,31 @@
   }
 }
 
-table tr .lucuma-visit-step-extra {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  padding-left: 5%;
+table tr {
+  .lucuma-sequence-visit-extraRow {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    padding-left: 5%;
 
-  .lucuma-visit-step-extra-datetime {
-    width: 20%;
-  }
+    .lucuma-sequence-visit-extraRow-datetime {
+      width: 20%;
+    }
 
-  .lucuma-visit-step-extra-datasets {
-    flex-grow: 1;
-    text-align: left;
+    .lucuma-sequence-visit-extraRow-datasets {
+      flex-grow: 1;
+      text-align: left;
 
-    .lucuma-visit-step-extra-dataset-item {
-      margin-right: 2.5dvw;
+      .lucuma-sequence-visit-extraRow-dataset-item {
+        margin-right: 2.5dvw;
 
-      .lucuma-visit-step-extra-dataset-status-icon {
-        padding-left: 0.5dvw;
-      }
+        .lucuma-sequence-visit-extraRow-dataset-status-icon {
+          padding-left: 0.5dvw;
+        }
 
-      .lucuma-visit-step-extra-dataset-status-label {
-        padding-left: 0.2dvw;
+        .lucuma-sequence-visit-extraRow-dataset-status-label {
+          padding-left: 0.2dvw;
+        }
       }
     }
   }

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-table.scss
@@ -82,7 +82,6 @@
       // Hover on this row, or in the next one if this one has subcomponent.
       &:hover,
       &.has-subcomponent:has(+ :hover) {
-        position: relative;
         background-color: var(--surface-100);
 
         &:not(.has-subcomponent) {
@@ -94,7 +93,6 @@
           box-shadow: inset 0 1px 0 0 var(--green-500);
 
           & + tr {
-            position: relative;
             background-color: var(--surface-100);
             box-shadow: inset 0 -1px 0 0 var(--green-500);
           }

--- a/modules/ui/src/main/scala/lucuma/ui/LucumaIcons.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/LucumaIcons.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui
+
+import lucuma.react.fa.*
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+object LucumaIcons:
+  @js.native
+  @JSImport("@fortawesome/pro-regular-svg-icons", "faCircle")
+  private val faCircle: FAIcon = js.native
+
+  FontAwesome.library.add(
+    faCircle
+  )
+
+  inline def Circle = FontAwesomeIcon(faCircle)

--- a/modules/ui/src/main/scala/lucuma/ui/react/givens.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/react/givens.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.react
+
+import cats.Monoid
+import japgolly.scalajs.react.React
+import japgolly.scalajs.react.vdom.html_<^.*
+
+given Monoid[VdomNode] = new Monoid[VdomNode]:
+  val empty: VdomNode = EmptyVdom
+  def combine(x: VdomNode, y: VdomNode): VdomNode = React.Fragment(x, y)
+
+given Monoid[TagMod] = new Monoid[TagMod]:
+  val empty: TagMod = TagMod.empty
+  def combine(x: TagMod, y: TagMod): TagMod = TagMod(x, y)

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceColumns.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceColumns.scala
@@ -7,11 +7,11 @@ import cats.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.*
+import lucuma.react.syntax.*
 import lucuma.react.table.*
 import lucuma.ui.syntax.all.*
-import lucuma.ui.table.HeaderOrRow
-import lucuma.ui.table.TableIcons
-import lucuma.ui.table.TableStyles
+import lucuma.ui.table.*
+import lucuma.ui.table.ColumnSize.*
 import lucuma.ui.utils.formatSN
 
 import SequenceRowFormatters.*
@@ -30,6 +30,38 @@ object SequenceColumns:
   val YBinColumnId: ColumnId         = ColumnId("Ybin")
   val ROIColumnId: ColumnId          = ColumnId("roi")
   val SNColumnId: ColumnId           = ColumnId("sn")
+
+  val BaseColumnSizes: Map[ColumnId, ColumnSize] = Map(
+    IndexAndTypeColumnId -> FixedSize(60.toPx),
+    ExposureColumnId     -> Resizable(77.toPx, min = 77.toPx.some, max = 130.toPx.some),
+    GuideColumnId        -> FixedSize(33.toPx),
+    PColumnId            -> FixedSize(75.toPx),
+    QColumnId            -> FixedSize(75.toPx),
+    WavelengthColumnId   -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some),
+    FPUColumnId          -> Resizable(132.toPx, min = 132.toPx.some, max = 180.toPx.some),
+    GratingColumnId      -> Resizable(120.toPx, min = 120.toPx.some, max = 180.toPx.some),
+    FilterColumnId       -> Resizable(90.toPx, min = 90.toPx.some, max = 150.toPx.some),
+    XBinColumnId         -> FixedSize(60.toPx),
+    YBinColumnId         -> FixedSize(60.toPx),
+    ROIColumnId          -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some),
+    SNColumnId           -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some)
+  )
+
+  // The order in which they are removed by overflow. The ones at the beginning go first.
+  // Missing columns are not removed by overflow. (We declare them in reverse order)
+  val BaseColumnPriorities: List[ColumnId] = List(
+    PColumnId,
+    QColumnId,
+    GuideColumnId,
+    ExposureColumnId,
+    SNColumnId,
+    ROIColumnId,
+    XBinColumnId,
+    YBinColumnId,
+    FilterColumnId,
+    GratingColumnId,
+    FPUColumnId
+  ).reverse
 
   def headerCell[T, R](
     colId:  ColumnId,

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceIndexedRow.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceIndexedRow.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.sequence
+
+case class SequenceIndexedRow[+D](step: SequenceRow[D], index: StepIndex)

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceRowBuilder.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceRowBuilder.scala
@@ -1,0 +1,199 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.sequence
+
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.DatasetQaState
+import lucuma.core.enums.SequenceType
+import lucuma.core.syntax.all.given
+import lucuma.core.util.Timestamp
+import lucuma.react.table.Expandable
+import lucuma.react.table.Expanded
+import lucuma.react.table.RowId
+import lucuma.schemas.model.AtomRecord
+import lucuma.schemas.model.Visit
+import lucuma.ui.LucumaIcons
+import lucuma.ui.LucumaStyles
+import lucuma.ui.display.given
+import lucuma.ui.format.DurationFormatter
+import lucuma.ui.format.UtcFormatter
+import lucuma.ui.sequence.*
+import lucuma.ui.table.*
+
+import java.time.Duration
+
+// Methods for building visits rows on the sequence table
+trait SequenceRowBuilder[D]:
+  protected type SequenceTableRowType = Expandable[HeaderOrRow[SequenceIndexedRow[D]]]
+
+  protected def getRowId(row: SequenceTableRowType): RowId =
+    row.value match
+      case Left(HeaderRow(rowId, _)) => rowId
+      case Right(stepRow)            => stepRow.step.rowId
+
+  protected val CurrentExpandedState =
+    Expanded.fromExpandedRows(
+      RowId(SequenceType.Acquisition.toString),
+      RowId(SequenceType.Science.toString)
+    )
+
+  protected case class VisitData(
+    visitId:      Visit.Id,
+    created:      Timestamp,
+    sequenceType: SequenceType,
+    stepRows:     NonEmptyList[SequenceIndexedRow[D]],
+    datasetRange: Option[(Short, Short)]
+  ):
+    val rowId: RowId = RowId(s"$visitId-sequenceType")
+
+  protected def renderVisitHeader(visit: VisitData): VdomNode =
+    <.div(SequenceStyles.VisitHeader)( // Steps is non-empty => head is safe
+      <.span(
+        s"${visit.sequenceType.shortName} Visit on ${UtcFormatter.format(visit.created.toInstant)}"
+      ),
+      <.span(s"Steps: ${visit.stepRows.head.index} - ${visit.stepRows.last.index}"),
+      <.span(
+        "Files: " + visit.datasetRange
+          .map((min, max) => s"$min - $max")
+          .getOrElse("---")
+      ),
+      <.span(
+        DurationFormatter(
+          visit.stepRows
+            .map(_.step.exposureTime.orEmpty.toDuration)
+            .reduce(_.plus(_))
+        )
+      )
+    )
+
+  protected def renderCurrentHeader(sequenceType: SequenceType): VdomNode =
+    <.span(SequenceStyles.CurrentHeader, sequenceType.toString)
+
+  protected def renderVisitExtraRow(step: SequenceRow.Executed.ExecutedStep[D]) =
+    <.div(SequenceStyles.VisitStepExtra)(
+      <.span(SequenceStyles.VisitStepExtraDatetime)(
+        step.interval
+          .map(_.start.toInstant)
+          .fold("---")(start => UtcFormatter.format(start))
+      ),
+      <.span(SequenceStyles.VisitStepExtraDatasets)(
+        step.datasets
+          .map: dataset =>
+            <.span(SequenceStyles.VisitStepExtraDatasetItem)(
+              dataset.filename.format,
+              dataset.qaState.map: qaState =>
+                React.Fragment(
+                  LucumaIcons.Circle.withClass(
+                    SequenceStyles.VisitStepExtraDatasetStatusIcon |+|
+                      (qaState match
+                        case DatasetQaState.Pass   => LucumaStyles.IndicatorOK
+                        case DatasetQaState.Usable => LucumaStyles.IndicatorWarning
+                        case DatasetQaState.Fail   => LucumaStyles.IndicatorFail
+                      )
+                  ),
+                  <.span(SequenceStyles.VisitStepExtraDatasetStatusLabel)(
+                    qaState.shortName
+                  )
+                )
+            )
+          .toVdomArray
+      )
+    )
+
+  private def buildVisitRows(
+    visitId:      Visit.Id,
+    atoms:        List[AtomRecord[D]],
+    sequenceType: SequenceType,
+    startIndex:   StepIndex = StepIndex.One
+  ): (Option[VisitData], StepIndex) =
+    atoms
+      .flatMap(_.steps)
+      .some
+      .filter(_.nonEmpty)
+      .map: steps =>
+        val datasetIndices = steps.flatMap(_.datasets).map(_.index.value)
+
+        (
+          steps.head.created,
+          steps
+            .map(SequenceRow.Executed.ExecutedStep(_, none)) // TODO Add SignalToNoise
+            .zipWithStepIndex(startIndex),
+          datasetIndices.minOption.map(min => (min, datasetIndices.max))
+        )
+      .map: (created, zipResult, datasetRange) =>
+        val (rows, nextIndex) = zipResult
+
+        (VisitData(
+           visitId,
+           created,
+           sequenceType,
+           NonEmptyList.fromListUnsafe(rows.map(SequenceIndexedRow(_, _))),
+           datasetRange
+         ).some,
+         nextIndex
+        )
+      .getOrElse:
+        (none, startIndex)
+
+  def visitsSequences(visits: List[Visit[D]]): (List[VisitData], StepIndex) =
+    visits
+      .foldLeft((List.empty[VisitData], StepIndex.One))((accum, visit) =>
+        val (seqs, index) = accum
+
+        // Acquisition indices restart at 1 in each visit.
+        // Science indices continue from one visit to the next.
+        val acquisition          =
+          buildVisitRows(visit.id, visit.acquisitionAtoms, SequenceType.Acquisition)._1
+        val (science, nextIndex) =
+          buildVisitRows(visit.id, visit.scienceAtoms, SequenceType.Science, index)
+
+        (
+          seqs ++ List(acquisition, science).flattenOption,
+          nextIndex
+        )
+      )
+
+  def stitchSequence(
+    visits:          List[VisitData],
+    nextIndex:       StepIndex,
+    acquisitionRows: List[SequenceRow[D]],
+    scienceRows:     List[SequenceRow[D]]
+  ): List[SequenceTableRowType] = {
+    val visitsRows: List[SequenceTableRowType] =
+      visits.map: visit =>
+        Expandable(
+          HeaderRow(visit.rowId, renderVisitHeader(visit)).toHeaderOrRow,
+          visit.stepRows.toList.map(step => Expandable(step.toHeaderOrRow))
+        )
+
+    def buildSequenceRows(
+      steps:        List[SequenceRow[D]],
+      sequenceType: SequenceType,
+      nextIndex:    StepIndex
+    ): List[SequenceTableRowType] =
+      Option
+        .when(steps.nonEmpty):
+          Expandable(
+            HeaderRow(
+              RowId(sequenceType.toString),
+              renderCurrentHeader(sequenceType)
+            ).toHeaderOrRow,
+            steps
+              .zipWithStepIndex(nextIndex)
+              ._1
+              .map: (step, index) =>
+                Expandable(SequenceIndexedRow(step, index).toHeaderOrRow)
+          )
+        .toList
+
+    val acquisitionTableRows: List[SequenceTableRowType] =
+      buildSequenceRows(acquisitionRows, SequenceType.Acquisition, StepIndex.One)
+    val scienceTableRows: List[SequenceTableRowType]     =
+      buildSequenceRows(scienceRows, SequenceType.Science, nextIndex)
+
+    visitsRows ++ acquisitionTableRows ++ scienceTableRows
+  }

--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceStyles.scala
@@ -9,17 +9,23 @@ object SequenceStyles:
   val SequenceTable: Css = Css("lucuma-sequence-table")
   val StepGuided: Css    = Css("lucuma-sequence-step-guided")
 
-  val TableHeader           = Css("lucuma-table-header")
-  val TableHeaderExpandable = Css("lucuma-table-header-expandable")
-  val TableHeaderContent    = Css("lucuma-table-header-content")
+  val TableHeader           = Css("lucuma-sequence-header")
+  val TableHeaderExpandable = Css("lucuma-sequence-header-expandable")
+  val TableHeaderContent    = Css("lucuma-sequence-header-content")
 
-  val VisitHeader                      = Css("lucuma-visit-header")
-  val VisitStepExtra                   = Css("lucuma-visit-step-extra")
-  val VisitStepExtraDatetime           = Css("lucuma-visit-step-extra-datetime")
-  val VisitStepExtraDatasets           = Css("lucuma-visit-step-extra-datasets")
-  val VisitStepExtraDatasetItem        = Css("lucuma-visit-step-extra-dataset-item")
-  val VisitStepExtraDatasetStatusIcon  = Css("lucuma-visit-step-extra-dataset-status-icon")
-  val VisitStepExtraDatasetStatusLabel = Css("lucuma-visit-step-extra-dataset-status-label")
+  val HiddenColTableHeader: Css = Css("lucuma-sequence-hidden-col-table-header")
+  val RowHasExtra: Css          = Css("lucuma-sequence-row-has-extra")
+  val ExtraRowShown: Css        = Css("lucuma-sequence-extra-row-shown")
+
+  val VisitHeader                      = Css("lucuma-sequence-visit-header")
+  val VisitStepExtra                   = Css("lucuma-sequence-visit-extraRow")
+  val VisitStepExtraDatetime           = Css("lucuma-sequence-visit-extraRow-datetime")
+  val VisitStepExtraDatasets           = Css("lucuma-sequence-visit-extraRow-datasets")
+  val VisitStepExtraDatasetItem        = Css("lucuma-sequence-visit-extraRow-dataset-item")
+  val VisitStepExtraDatasetStatusIcon  = Css("lucuma-sequence-visit-extraRow-dataset-status-icon")
+  val VisitStepExtraDatasetStatusLabel = Css("lucuma-sequence-visit-extraRow-dataset-status-label")
+
+  val CurrentHeader = Css("lucuma-sequence-current-header")
 
   object StepType:
     val Bias: Css   = Css("lucuma-sequence-step-type-bias")

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/util.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/util.scala
@@ -3,11 +3,8 @@
 
 package lucuma.ui.syntax
 
-import cats.Monoid
 import japgolly.scalajs.react.Callback
-import japgolly.scalajs.react.React
 import japgolly.scalajs.react.Reusable
-import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.EnumValue
 
 import scala.scalajs.js
@@ -15,14 +12,6 @@ import scala.scalajs.js
 trait util:
   extension [A](a: A | Unit)(using ev: EnumValue[A])
     def undefToJs: js.UndefOr[String] = a.map(ev.value)
-
-  given Monoid[VdomNode] = new Monoid[VdomNode]:
-    val empty: VdomNode = EmptyVdom
-    def combine(x: VdomNode, y: VdomNode): VdomNode = React.Fragment(x, y)
-
-  given Monoid[TagMod] = new Monoid[TagMod]:
-    val empty: TagMod = TagMod.empty
-    def combine(x: TagMod, y: TagMod): TagMod = TagMod(x, y)
 
   extension (c: Callback.type) def pprintln[T](a: T): Callback = Callback(_root_.pprint.pprintln(a))
 


### PR DESCRIPTION
Extract all common logic from observe and explore so that they share as much as possible of the logic for displaying their sequence tables.

Also, moved `Monoid[VdomNode]` and `Monoid[TagMod]` to a better-named package.