### PR TITLE
Allow filtering of SideTabs buttons, update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.97"
+ThisBuild / tlBaseVersion       := "0.98"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {
@@ -12,11 +12,11 @@ val Versions = new {
   val kittens           = "3.3.0"
   val http4s            = "0.23.26"
   val http4sDom         = "0.2.11"
-  val lucumaCore        = "0.94.1"
+  val lucumaCore        = "0.96.0"
   val lucumaPrimeStyles = "0.2.10"
   val lucumaReact       = "0.56.0"
   val lucumaRefined     = "0.1.2"
-  val lucumaSchemas     = "0.78.1"
+  val lucumaSchemas     = "0.81.0"
   val lucumaSso         = "0.6.15"
   val monocle           = "3.2.0"
   val mouse             = "1.2.3"

--- a/modules/ui/src/main/scala/lucuma/ui/components/SideTabs.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/SideTabs.scala
@@ -27,7 +27,8 @@ case class SideTabs[A](
   id:             NonEmptyString,
   tab:            View[A],
   pageUrl:        A => String,
-  separatorAfter: A => Boolean
+  separatorAfter: A => Boolean,
+  filterPred:     A => Boolean = (_: A) => true
 )(using val enumerated: Enumerated[A], val display: Display[A])
     extends ReactFnProps(SideTabs.component)
 
@@ -48,6 +49,7 @@ object SideTabs:
             p.id,
             p.tab,
             buttonClass = SideTabsStyles.SideButton,
+            filterPred = p.filterPred,
             itemTemplate = tab =>
               <.div(
                 SideTabsStyles.RotationWrapperOuter |+|
@@ -71,6 +73,7 @@ object SideTabs:
             p.tab,
             groupClass = SideTabsStyles.SideTabsHorizontal,
             buttonClass = SideTabsStyles.TabSelector,
+            filterPred = p.filterPred,
             itemTemplate = tab =>
               <.a(
                 ^.onClick ==> ((e: ReactEvent) => e.preventDefaultCB),

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/SelectButtonEnumView.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/SelectButtonEnumView.scala
@@ -24,6 +24,7 @@ case class SelectButtonEnumView[V[_], A](
   itemTemplate:   js.UndefOr[SelectItem[A] => VdomNode] = js.undefined,
   disabled:       js.UndefOr[Boolean] = js.undefined,
   onChange:       A => Callback = (_: A) => Callback.empty,
+  filterPred:     A => Boolean = (_: A) => true,
   modifiers:      Seq[TagMod] = Seq.empty
 )(using
   val enumerated: Enumerated[A],
@@ -45,9 +46,11 @@ object SelectButtonEnumView {
       props.view.get.map { value =>
         SelectButton[A](
           value = value,
-          Enumerated[A].all.map { s =>
-            SelectItem(s, label = props.display.shortName(s), clazz = props.buttonClass)
-          },
+          Enumerated[A].all
+            .filter(props.filterPred)
+            .map { s =>
+              SelectItem(s, label = props.display.shortName(s), clazz = props.buttonClass)
+            },
           id = props.id.value,
           clazz = props.groupClass,
           itemTemplate = props.itemTemplate,


### PR DESCRIPTION
This allows us to hide buttons in the `SideTabs` by using a filter predicate. This also provides the filter predicate on `SelectButtonEnumView`.

One side effect is that if a filtered button is one for with `separatorAfter` returns true, that extra spacing will be lost. In the particular case I want this for (hiding the Proposal button in Explore), this is a good thing. It's not necessarily a good thing in the general case. Creative use of the `seperatorAfter` function could fix any problem if needed...