### PR TITLE
Leave some sequence columns unbounded

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceColumns.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceColumns.scala
@@ -33,18 +33,18 @@ object SequenceColumns:
 
   val BaseColumnSizes: Map[ColumnId, ColumnSize] = Map(
     IndexAndTypeColumnId -> FixedSize(60.toPx),
-    ExposureColumnId     -> Resizable(77.toPx, min = 77.toPx.some, max = 130.toPx.some),
+    ExposureColumnId     -> Resizable(77.toPx, min = 77.toPx, max = 130.toPx),
     GuideColumnId        -> FixedSize(33.toPx),
     PColumnId            -> FixedSize(75.toPx),
     QColumnId            -> FixedSize(75.toPx),
-    WavelengthColumnId   -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some),
-    FPUColumnId          -> Resizable(132.toPx, min = 132.toPx.some, max = 180.toPx.some),
-    GratingColumnId      -> Resizable(120.toPx, min = 120.toPx.some, max = 180.toPx.some),
-    FilterColumnId       -> Resizable(90.toPx, min = 90.toPx.some, max = 150.toPx.some),
+    WavelengthColumnId   -> Resizable(75.toPx, min = 75.toPx, max = 130.toPx),
+    FPUColumnId          -> Resizable(132.toPx, min = 132.toPx),
+    GratingColumnId      -> Resizable(120.toPx, min = 120.toPx),
+    FilterColumnId       -> Resizable(90.toPx, min = 90.toPx),
     XBinColumnId         -> FixedSize(60.toPx),
     YBinColumnId         -> FixedSize(60.toPx),
-    ROIColumnId          -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some),
-    SNColumnId           -> Resizable(75.toPx, min = 75.toPx.some, max = 130.toPx.some)
+    ROIColumnId          -> Resizable(75.toPx, min = 75.toPx),
+    SNColumnId           -> Resizable(75.toPx, min = 75.toPx, max = 130.toPx)
   )
 
   // The order in which they are removed by overflow. The ones at the beginning go first.

--- a/modules/ui/src/main/scala/lucuma/ui/table/ColumnSize.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/ColumnSize.scala
@@ -24,6 +24,9 @@ object ColumnSize:
     def apply(initial: SizePx, min: SizePx, max: SizePx): Resizable =
       Resizable(initial, min.some, max.some)
 
+    def apply(initial: SizePx, min: SizePx): Resizable =
+      Resizable(initial, min.some, none)
+
   extension [T, V](col: ColumnDef.Single[T, V])
     def setColumnSize(size: ColumnSize): ColumnDef.Single[T, V] =
       col

--- a/modules/ui/src/main/scala/lucuma/ui/table/hooks/DynTable.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/hooks/DynTable.scala
@@ -109,7 +109,7 @@ case class DynTable(
 
           // If bounded columns are more than the viewport width, drop the lowest priority column and start again.
           if (totalBounded > width.value && prioritizedRemainingCols.nonEmpty)
-            // We must remove columns one by one, since removing one causes the resto to recompute.
+            // We must remove columns one by one, since removing one causes the rest to recompute.
             go1(overflowColumn)
           else
             val remainingSpace: Int = width.value - totalBounded


### PR DESCRIPTION
This allows the table to fill up the whole width on large screens.