### PR TITLE
Alert rows in sequences

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.100"
+ThisBuild / tlBaseVersion       := "0.101"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {


### PR DESCRIPTION
Contemplates adding alert rows in sequences, which are needed for: continue acquisition prompts, targets of opportunity, suggestions to interrupt sequence because of conditions.