### PR TITLE
Fix sequence section hiding criterion

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceRowBuilder.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sequence/SequenceRowBuilder.scala
@@ -219,7 +219,7 @@ trait SequenceRowBuilder[D]:
       nextIndex:        StepIndex
     ): List[SequenceTableRowType] =
       Option
-        .when(steps.nonEmpty):
+        .when(currentVisitRows.nonEmpty || steps.nonEmpty):
           Expandable(
             HeaderRow(
               RowId(sequenceType.toString),


### PR DESCRIPTION
A section now is a stitching of the executed rows and the pending rows. We hide a section if there are no rows, but we were only looking at the pending rows, not the executed ones. This PR fixes that.