### PR TITLE
Fix step numbering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.101"
+ThisBuild / tlBaseVersion       := "0.102"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {


### PR DESCRIPTION
Step numbering missed an index when there was a step running.

This happened because the executing step is already recorded but hidden.

The current PR removes such step before indices are computed, instead of after.