### PR TITLE
Check token expiration every second

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.108"
+ThisBuild / tlBaseVersion       := "0.109"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
@@ -36,16 +36,15 @@ object ConnectionManager {
     .withPropsChildren
     .useState(false) // initialized as state, which forces rerender on set
     .useRef(false)   // initialized as ref, which can be read asynchronously by cleanup
-    .useEffectWithDepsBy((props, _, _, _) => props.vault.token) {
-      (props, _, initializedState, _) => _ =>
+    .useEffectWithDepsBy((props, _, _, _) => props.vault.token): (props, _, initializedState, _) =>
+      _ =>
         import props.given
 
         // In clue, connect will be a no-op (with a warn) and initialize will restart the protocol and reestablish subscriptions.
         (Logger[DefaultA].debug(s"[ConnectionManager] Token changed. Refreshing connections.") >>
           props.openConnections(props.payload))
           .whenA(initializedState.value)
-    }
-    .useAsyncEffectOnMountBy { (props, _, initializedState, initializedRef) =>
+    .useAsyncEffectOnMountBy: (props, _, initializedState, initializedRef) =>
       import props.given
 
       val initialize: DefaultA[Unit] =
@@ -61,11 +60,9 @@ object ConnectionManager {
         )
 
       initialize.as(cleanup)
-    }
-    .render((props, children, initializedState, _) =>
+    .render: (props, children, initializedState, _) =>
       if (initializedState.value)
         children
       else
         SolarProgress()
-    )
 }

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
@@ -66,4 +66,4 @@ object SSOManager:
               yield ())
                 .onError: t =>
                   Logger[DefaultA].error(t)("Error refreshing user token") >> props.setVault(none)
-      .render((props, _) => EmptyVdom) // This is a "phantom" component. Doesn't render anything.
+      .render((_, _) => EmptyVdom) // This is a "phantom" component. Doesn't render anything.

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
@@ -3,7 +3,9 @@
 
 package lucuma.ui.components.state
 
+import cats.effect.Async
 import cats.effect.IO
+import cats.effect.Sync
 import cats.syntax.all.*
 import crystal.react.*
 import crystal.react.hooks.*
@@ -13,57 +15,55 @@ import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.ReactFnProps
 import lucuma.refined.*
+import lucuma.ui.reusability.given
 import lucuma.ui.sso.SSOClient
 import lucuma.ui.sso.UserVault
 import org.typelevel.log4cats.Logger
 
 import java.time.Instant
+import scala.concurrent.duration.*
 
 case class SSOManager(
   ssoClient:  SSOClient[DefaultA],
   expiration: Instant,
   setVault:   Option[UserVault] => DefaultA[Unit],
   setMessage: NonEmptyString => DefaultA[Unit]
-)(using val logger: Logger[DefaultA])
+)(using val F: Async[DefaultA], val logger: Logger[DefaultA])
     extends ReactFnProps(SSOManager.component)
 
 object SSOManager:
   private type Props = SSOManager
 
-  private def tokenRefresher(
-    expiration: Instant,
-    setVault:   Option[UserVault] => DefaultA[Unit],
-    setMessage: NonEmptyString => DefaultA[Unit],
-    ssoClient:  SSOClient[DefaultA]
-  ): DefaultA[Unit] =
-    for {
-      vaultOpt <- ssoClient.refreshToken(expiration)
-      _        <- setVault(vaultOpt)
-      _        <- vaultOpt.fold(setMessage("Your session has expired".refined))(vault =>
-                    tokenRefresher(vault.expiration, setVault, setMessage, ssoClient)
-                  )
-    } yield ()
+  // We check the expiration periodically instead of using a timeout to the next expiration.
+  // This ensures that we resync again if the computer goes to sleep.
+  private val ExpirationCheckInterval: FiniteDuration = 1.second
 
   private val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useRef(none[DefaultA[Unit]]) // cancelToken
-      .useAsyncEffectOnMountBy { (props, cancelToken) =>
-        import props.given
+      // Needed because of the infamous bug where useEffect doesn't run if it's the only hook.
+      .useState(())
+      .useEffectStreamWithDepsBy((props, _) => props.expiration): (props, _) =>
+        expiration =>
+          import props.given
 
-        tokenRefresher(props.expiration, props.setVault, props.setMessage, props.ssoClient)
-          .onError(t =>
-            Logger[DefaultA].error(t)("Error refreshing SSO token") >>
-              (props.setVault(none) >>
-                props.setMessage(
-                  "There was an error while checking the validity of your session".refined
-                ))
-          )
-          .start
-          .flatMap(fiber => cancelToken.setAsync(fiber.cancel.some))
-          .as(
-            cancelToken.getAsync >>=
-              (cancelOpt => cancelOpt.foldMap(_ >> props.setVault(none)))
-          )
-      }
-      .render((_, _) => EmptyVdom) // This is a "phantom" component. Doesn't render anything.
+          val refreshInstant: Instant =
+            expiration.minus(props.ssoClient.config.expirationAnticipation)
+
+          fs2.Stream
+            .awakeDelay(ExpirationCheckInterval)
+            .evalMap(_ => Sync[DefaultA].delay(Instant.now))
+            .takeThrough(_.isBefore(refreshInstant)) // When the stream ends, refresh the token.
+            .void ++
+            fs2.Stream.eval:
+              (for
+                _        <- Logger[DefaultA].debug("Refreshing user token")
+                vaultOpt <- props.ssoClient.whoami
+                _        <- Logger[DefaultA].debug:
+                              s"User token refreshed. New expiration: ${vaultOpt.map(_.expiration)}."
+                _        <- props.setVault(vaultOpt)
+                _        <- props.setMessage("Your session has expired".refined).whenA(vaultOpt.isEmpty)
+              yield ())
+                .onError: t =>
+                  Logger[DefaultA].error(t)("Error refreshing user token") >> props.setVault(none)
+      .render((props, _) => EmptyVdom) // This is a "phantom" component. Doesn't render anything.

--- a/modules/ui/src/main/scala/lucuma/ui/sso/SSOConfig.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/sso/SSOConfig.scala
@@ -11,17 +11,16 @@ import io.circe.*
 import org.http4s.Uri
 import org.http4s.circe.*
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 case class SSOConfig(
-  uri:                        Uri,
-  readTimeoutSeconds:         Long = 3,
-  refreshTimeoutDeltaSeconds: Long = 10, // time before expiration to renew
-  refreshIntervalFactor:      Long = 1
+  uri:                           Uri,
+  readTimeoutSeconds:            Long = 3,
+  expirationAnticipationSeconds: Long = 10 // time before expiration to renew
 ) derives Eq,
       Show,
       Decoder:
-  val readTimeout: FiniteDuration         = FiniteDuration(readTimeoutSeconds, TimeUnit.SECONDS)
-  val refreshTimeoutDelta: FiniteDuration =
-    FiniteDuration(refreshTimeoutDeltaSeconds, TimeUnit.SECONDS)
+  val readTimeout: FiniteDuration      = FiniteDuration(readTimeoutSeconds, TimeUnit.SECONDS)
+  val expirationAnticipation: Duration = Duration.ofSeconds(expirationAnticipationSeconds)


### PR DESCRIPTION
This seems to fix the issue where explore enters a endless loop of attempting to connect to the ODB with stale credentials when a laptop is left closed for some time.

With this fix, I could prevent the error from happening several times, but in one of the tests it happened again, so let's keep an eye out. There may be some other place in the code that needs tweaking.

BTW, the state where this happened is not "Sleep", at least on a Mac. If a Mac enters sleep, the browser will refresh the page when it wakes up. So, this happens on a Mac when you close the lid and the computer is on AC power (if it's on battery, it enters sleep when you close the lid).