### PR TITLE
Don't reconnect WS when auth token changes

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,4 @@
 include ".scalafix-common.conf"
 
 OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = Scala3

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.110"
+ThisBuild / tlBaseVersion       := "0.111"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {
@@ -18,7 +18,7 @@ val Versions = new {
   val lucumaPrimeStyles = "0.3.0"
   val lucumaReact       = "0.69.0"
   val lucumaRefined     = "0.1.2"
-  val lucumaSchemas     = "0.90.7"
+  val lucumaSchemas     = "0.91.0"
   val lucumaSso         = "0.6.20"
   val monocle           = "3.2.0"
   val mouse             = "1.3.1"

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
@@ -3,6 +3,7 @@
 
 package lucuma.ui.components.state
 
+import cats.effect.Resource
 import cats.syntax.all.*
 import crystal.react.*
 import crystal.react.hooks.*
@@ -12,15 +13,13 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.ReactFnPropsWithChildren
-import lucuma.ui.components.SolarProgress
-import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
-import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.all.*
 import org.typelevel.log4cats.Logger
 
 case class ConnectionManager(
   vault:            UserVault,
-  openConnections:  Map[String, Json] => DefaultA[Unit],
+  openConnections:  DefaultA[Map[String, Json]] => DefaultA[Unit],
   closeConnections: DefaultA[Unit],
   onConnect:        DefaultA[Unit]
 )(using
@@ -28,41 +27,14 @@ case class ConnectionManager(
 ) extends ReactFnPropsWithChildren(ConnectionManager.component):
   val payload: Map[String, Json] = Map("Authorization" -> vault.authorizationHeader.asJson)
 
-object ConnectionManager {
+object ConnectionManager:
   private type Props = ConnectionManager
 
   private val component = ScalaFnComponent
     .withHooks[Props]
     .withPropsChildren
-    .useState(false) // initialized as state, which forces rerender on set
-    .useRef(false)   // initialized as ref, which can be read asynchronously by cleanup
-    .useEffectWithDepsBy((props, _, _, _) => props.vault.token): (props, _, initializedState, _) =>
-      _ =>
-        import props.given
-
-        // In clue, connect will be a no-op (with a warn) and initialize will restart the protocol and reestablish subscriptions.
-        (Logger[DefaultA].debug(s"[ConnectionManager] Token changed. Refreshing connections.") >>
-          props.openConnections(props.payload))
-          .whenA(initializedState.value)
-    .useAsyncEffectOnMountBy: (props, _, initializedState, initializedRef) =>
-      import props.given
-
-      val initialize: DefaultA[Unit] =
-        props.openConnections(props.payload) >>
-          initializedRef.setAsync(true) >>
-          initializedState.setStateAsync(true) >>
-          props.onConnect
-
-      val cleanup: DefaultA[Unit] =
-        initializedRef.getAsync >>= (initialized =>
-          (Logger[DefaultA].debug(s"[ConnectionManager] Terminating connections.") >>
-            props.closeConnections).whenA(initialized)
-        )
-
-      initialize.as(cleanup)
-    .render: (props, children, initializedState, _) =>
-      if (initializedState.value)
-        children
-      else
-        SolarProgress()
-}
+    .useShadowRef(pc => pc.props.payload)
+    .useResourceOnMountBy: (props, _, payloadRef) => // Returns Pot[Unit]; Ready when connected.
+      Resource.make(props.openConnections(payloadRef.getAsync))(_ => props.closeConnections)
+    .render: (_, children, _, connectedPot) =>
+      connectedPot.renderPot(_ => children)

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/IfLogged.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/IfLogged.scala
@@ -25,7 +25,7 @@ case class IfLogged[E](
   ssoClient:            SSOClient[DefaultA],
   userVault:            View[Option[UserVault]],
   userSelectionMessage: View[Option[NonEmptyString]],
-  openConnections:      Map[String, Json] => DefaultA[Unit],
+  openConnections:      DefaultA[Map[String, Json]] => DefaultA[Unit],
   closeConnections:     DefaultA[Unit],
   onConnect:            DefaultA[Unit],
   channelName:          NonEmptyString,

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/SSOManager.scala
@@ -48,7 +48,9 @@ object SSOManager:
           val refreshInstant: Instant =
             expiration.minus(props.ssoClient.config.expirationAnticipation)
 
-          fs2.Stream
+          fs2.Stream.eval:
+            Logger[DefaultA].debug(s"Next token refresh: $refreshInstant")
+          ++ fs2.Stream
             .awakeDelay(ExpirationCheckInterval)
             .evalMap(_ => Sync[DefaultA].delay(Instant.now))
             .takeThrough(_.isBefore(refreshInstant)) // When the stream ends, refresh the token.

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/view.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/view.scala
@@ -41,4 +41,4 @@ trait view:
     def zoomSplitEpi[B](splitEpi: SplitEpi[A, B])(implicit ev: Monad[F]): Reuse[ViewOptF[F, B]] =
       self.zoom(splitEpi.get)(splitEpi.modify)
 
-object views extends view
+object view extends view


### PR DESCRIPTION
We use effectful initialization payloads now, which make clue's retry mechanism always use the latest token upon reconnection.

I removed the redundant reconnect mechanism in `ConnectionManager` and simplified the connection logic by using `useResource`.