### PR TITLE
Reset UI when user or role change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.115"
+ThisBuild / tlBaseVersion       := "0.116"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/ConnectionManager.scala
@@ -35,6 +35,7 @@ object ConnectionManager:
     .withPropsChildren
     .useShadowRef(pc => pc.props.payload)
     .useResourceOnMountBy: (props, _, payloadRef) => // Returns Pot[Unit]; Ready when connected.
-      Resource.make(props.openConnections(payloadRef.getAsync))(_ => props.closeConnections)
+      Resource.make(props.openConnections(payloadRef.getAsync))(_ => props.closeConnections) >>
+        Resource.eval(props.onConnect)
     .render: (_, children, _, connectedPot) =>
       connectedPot.renderPot(_ => children)

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/IfLogged.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/IfLogged.scala
@@ -58,7 +58,7 @@ object IfLogged:
           props.userSelectionMessage,
           props.allowGuest
         )
-      ) { vault =>
+      ): vault =>
         React.Fragment(
           SSOManager(props.ssoClient, vault.expiration, vaultSet, messageSet),
           ConnectionManager(
@@ -66,7 +66,7 @@ object IfLogged:
             props.openConnections,
             props.closeConnections,
             props.onConnect
-          )(
+          ).withKey(s"${vault.user.id}-${vault.user.role.toString}")(
             LogoutTracker(
               vaultSet,
               messageSet,
@@ -77,6 +77,5 @@ object IfLogged:
             )(props.render(_))
           )
         )
-      }
 
   private val component = componentBuilder[Any]

--- a/modules/ui/src/main/scala/lucuma/ui/components/state/LogoutTracker.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/components/state/LogoutTracker.scala
@@ -34,11 +34,10 @@ object LogoutTracker:
       .withHooks[Props[E]]
       // Create a nonce
       .useMemo(())(_ => System.currentTimeMillis)
-      .useResourceOnMountBy { (props, _) =>
+      .useResourceOnMountBy: (props, _) =>
         import props.given
         BroadcastChannel[DefaultA, E](props.channelName.value)
-      }
-      .useStreamBy((_, _, bc) => bc.isReady)((props, nonce, bc) =>
+      .useStreamBy((_, _, bc) => bc.isReady): (props, nonce, bc) =>
         _ =>
           bc.toOption.map(_.messages).orEmpty.evalTap { e =>
             if (props.isLogoutEvent(e.data))
@@ -48,16 +47,12 @@ object LogoutTracker:
             else
               Applicative[DefaultA].unit
           }
-      )
-      .render { (props, nonce, bc, _) =>
-        bc.toOption.fold[VdomNode](React.Fragment())(bc =>
-          props.render(
-            bc.postMessage(
+      .render: (props, nonce, bc, _) =>
+        bc.toOption.fold[VdomNode](React.Fragment()): bc =>
+          props.render:
+            bc.postMessage:
               props.createEventWithNonce(nonce.value.toString)
-            ).attempt
+            .attempt
               .void
-          )
-        )
-      }
 
   private val component = componentBuilder[Any]


### PR DESCRIPTION
Force the connections to reset and the UI to rerender completely when the new connection is established.