### PR TITLE
Allow filtering of columns in ColumnSelector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.117"
+ThisBuild / tlBaseVersion       := "0.118"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {

--- a/modules/ui/src/main/scala/lucuma/ui/table/ColumnSelector.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/ColumnSelector.scala
@@ -17,7 +17,7 @@ import lucuma.ui.primereact.LucumaPrimeStyles
 
 case class ColumnSelector[T, M](
   table:       Table[T, M],
-  columnNames: ColumnId => String,
+  columnNames: ColumnId => Option[String],
   clazz:       Css = Css.Empty
 ) extends ReactFnProps(ColumnSelector.component)
 
@@ -29,19 +29,24 @@ object ColumnSelector:
       .withHooks[Props[T, M]]
       .usePopupMenuRef
       .render { (props, menuRef) =>
-        val menuItems = props.table.getAllColumns().drop(1).map { column =>
-          val colId = column.id
-          MenuItem.Custom(
-            <.div(
-              LucumaPrimeStyles.CheckboxWithLabel,
-              Checkbox(id = colId.value,
-                       checked = column.getIsVisible(),
-                       onChange = _ => column.toggleVisibility()
-              ),
-              <.label(^.htmlFor := colId.value, props.columnNames(colId))
-            )
-          )
-        }
+        val menuItems =
+          props.table
+            .getAllColumns()
+            .drop(1)
+            .filter(col => props.columnNames(col.id).isDefined)
+            .map { column =>
+              val colId = column.id
+              MenuItem.Custom(
+                <.div(
+                  LucumaPrimeStyles.CheckboxWithLabel,
+                  Checkbox(id = colId.value,
+                           checked = column.getIsVisible(),
+                           onChange = _ => column.toggleVisibility()
+                  ),
+                  <.label(^.htmlFor := colId.value, props.columnNames(colId))
+                )
+              )
+            }
         React.Fragment(
           Button(
             label = "Columns",


### PR DESCRIPTION
This allows excluding columns from the column selection list - only columns for which the `columnNames` function returns a value will be included in the selection list.

I was deciding between doing it this way, or providing an `excludedColumns` as a `Set[ColumnId]`. I opted for this method since in explore we are using a Map for the `columnNames`, so this seemed safer. By using `map.get` instead of `map.apply` we eliminate a potential exception.