### PR TITLE
Apply table states partially in case of overrides

### DIFF
--- a/modules/ui/src/main/scala/lucuma/ui/table/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/table/package.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.ui.table
+
+import crystal.react.View
+import lucuma.react.table.Updater
+
+def stateInViewHandler[S](view: View[S]) = (u: Updater[S]) =>
+  u match
+    case Updater.Set(v) => view.set(v)
+    case Updater.Mod(f) => view.mod(f)


### PR DESCRIPTION
In case of partial table state overrides (which is what we usually use), we have to define a setter for the partial state. This setter is not triggered when a `setState` or `modState` is invoked for the full state. Therefore, we now invoke the partial state handlers independently to ensure the partial handlers are called when loading state.

I also added a convenience method to help delegate partial state to a `View`.