### PR TITLE
Implement toast.showDuring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,17 +15,17 @@ val Versions = new {
   val http4s            = "0.23.30"
   val http4sDom         = "0.2.11"
   val log4catsLogLevel  = "0.3.1"
-  val lucumaCore        = "0.113.0"
+  val lucumaCore        = "0.112.2"
   val lucumaPrimeStyles = "0.3.0"
   val lucumaReact       = "0.78.1"
   val lucumaRefined     = "0.1.2"
   val lucumaSchemas     = "0.110.3"
-  val lucumaSso         = "0.7.3"
+  val lucumaSso         = "0.7.2"
   val monocle           = "3.3.0"
   val mouse             = "1.3.2"
   val munit             = "1.0.4"
   val pprint            = "0.9.0"
-  val scalaJsReact      = "3.0.0-beta8"
+  val scalaJsReact      = "3.0.0-beta10"
 }
 
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-common.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-common.scss
@@ -42,7 +42,7 @@ a:hover {
 
     /* stylelint-disable-next-line selector-class-pattern */
     span > svg.svg-inline--fa {
-      padding-right: 0.5em;
+      margin-right: 0.5em;
     }
   }
 }

--- a/modules/ui/src/main/scala/lucuma/ui/syntax/toast.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/syntax/toast.scala
@@ -3,6 +3,12 @@
 
 package lucuma.ui.syntax
 
+import cats.Monoid
+import cats.effect.Sync
+import cats.effect.std.UUIDGen
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
+import crystal.react.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.Css
@@ -28,5 +34,34 @@ trait toast:
           clazz = LucumaStyles.Toast
         )
       )
+
+    def showDuring[F[_]: Sync: UUIDGen](fa: F[Unit])(
+      text:         String,
+      completeText: Option[String] = none,
+      errorText:    Option[String] = none
+    )(using Monoid[F[Unit]]): F[Unit] =
+      for
+        id  <- UUIDGen[F].randomUUID
+        item = MessageItem(
+                 id = id.toString,
+                 content = <.span(
+                   LucumaIcons.CircleNotch.withSize(IconSize.LG).withFixedWidth(true),
+                   text
+                 ),
+                 severity = Message.Severity.Info,
+                 clazz = LucumaStyles.Toast,
+                 sticky = true,
+                 closable = false
+               )
+        _   <- toastRef.show(item).to[F]
+        _   <- fa.guarantee(toastRef.remove(item).to[F])
+                 .flatMap(_ => completeText.map(show(_).to[F]).orEmpty)
+                 .onError: e =>
+                   show(
+                     text = errorText.getOrElse(s"Error during operation: ${e.getMessage}"),
+                     severity = Message.Severity.Error,
+                     sticky = true
+                   ).to[F]
+      yield ()
 
 object toast extends toast


### PR DESCRIPTION
Show a toast with a spinner while an effect is running and replaces it with a success or error toast when it completes.

Also dials back versions of core and sso since the new versions introduce a linking error in explore.