### PR TITLE
Rework FormTimeSpanInput

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.135"
+ThisBuild / tlBaseVersion       := "0.136"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 val Versions = new {

--- a/modules/ui/src/main/resources/lucuma-css/lucuma-ui-prime.scss
+++ b/modules/ui/src/main/resources/lucuma-css/lucuma-ui-prime.scss
@@ -323,6 +323,10 @@
 .p-time-span-input {
   display: flex;
   gap: 0.5em;
+
+  input {
+    min-width: 2em;
+  }
 }
 
 .pl-react-table.pl-very-compact .p-datatable-tbody > tr > td.p-datatable-emptymessage {

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/FormTimeSpanInput.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/FormTimeSpanInput.scala
@@ -14,6 +14,7 @@ import lucuma.core.util.TimeSpan
 import lucuma.react.common.Css
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.*
+import lucuma.react.primereact.tooltip.*
 import lucuma.ui.display.given
 import lucuma.ui.reusability.given
 
@@ -29,7 +30,8 @@ case class FormTimeSpanInput[V[_]](
   min:      js.UndefOr[TimeSpan] = js.undefined,
   max:      js.UndefOr[TimeSpan] = js.undefined,
   disabled: Boolean = false,
-  clazz:    js.UndefOr[Css] = js.undefined
+  clazz:    js.UndefOr[Css] = js.undefined,
+  tooltip:  js.UndefOr[VdomNode] = js.undefined
 )(using val vl: ViewLike[V])
     extends ReactFnProps(FormTimeSpanInput.component)
 
@@ -83,7 +85,7 @@ object FormTimeSpanInput:
 
       React.Fragment(
         props.label.map(l => FormLabel(htmlFor = props.id)(l)),
-        input
+        props.tooltip.fold(input)(tt => input.withTooltip(content = tt))
       )
 
   protected val component = componentBuilder[AnyF]

--- a/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaPrimeStyles.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/primereact/LucumaPrimeStyles.scala
@@ -42,7 +42,6 @@ trait LucumaPrimeStyles:
     val Small: Css = Css("pl-dialog-small")
     val Large: Css = Css("pl-dialog-large")
 
-  val TimeSpanInput: Css     = Css("p-time-span-input")
-  val TimeSpanInputItem: Css = Css("pl-time-span-input-item")
+  val TimeSpanInput: Css = Css("p-time-span-input")
 
 object LucumaPrimeStyles extends LucumaPrimeStyles


### PR DESCRIPTION
Initially I just wanted to add a tooltip. But, I discovered that when using the min/max parameters, the inputs would not update if the value had to be "clamped" to the min/max range. I tried several things and could not get the InputNumber controls to update, so I switched to FormInputTextViews. This also unified the units display with how explore is doing it. I.e., combined with the input like: 
<img width="150" alt="image" src="https://github.com/user-attachments/assets/c2785722-1b03-4af1-ae53-0288bacdef16" />
Instead of separate from it like: 
![image](https://github.com/user-attachments/assets/242b0aac-03b8-4856-8619-f536fd0c4150)
