### PR TITLE
Smarter reusability for fov

### DIFF
--- a/modules/demo/vite.config.js
+++ b/modules/demo/vite.config.js
@@ -2,7 +2,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import env from 'vite-plugin-env-compatible';
 
-const scalaVersion = '3.6.4';
+const scalaVersion = '3.7.1';
 
 // https://vitejs.dev/config/
 export default ({ command, mode }) => {

--- a/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
+++ b/modules/ui/src/main/scala/lucuma/ui/reusability/package.scala
@@ -171,7 +171,12 @@ trait SequenceReusabilityInstances:
 
 trait AladinReusabilityInstances extends UtilReusabilityInstances:
 
-  private given Reusability[Double] = Reusability.double(0.00001)
+  private given Reusability[Double] = Reusability {
+    case (0.0, 0.0) => true
+    case (0.0, a)   => true
+    case (a, 0.0)   => true
+    case (a, b)     => (a.abs / b.abs) > 0.01 // 1% it is just a heuristic
+  }
 
   // check every field except customizee
   // I'm running over the 22 field limit. I'll just split it


### PR DESCRIPTION
this one was tricky, the reusabilty for aladin depends on fov too, but what difference is meaningful for fov (a double)
we had a fixed number but that degenarates into infinite redraws at larger zooms.

now we'll use a percentage instead.