### PR TITLE
Make partnerLink non-optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.154"
+ThisBuild / tlBaseVersion       := "0.155"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 
 val Versions = new {

--- a/modules/schemas/lucuma-schemas/src/main/scala/lucuma/schemas/odb/input/package.scala
+++ b/modules/schemas/lucuma-schemas/src/main/scala/lucuma/schemas/odb/input/package.scala
@@ -318,14 +318,14 @@ extension (etm: ExposureTimeMode)
         SignalToNoiseExposureTimeModeInput(value = value, at = at.toInput).assign
       )
 
-extension (pl: Option[PartnerLink])
+extension (pl: PartnerLink)
   def toInput: PartnerLinkInput =
     pl match
-      case Some(PartnerLink.HasPartner(p)) =>
+      case PartnerLink.HasPartner(p)         =>
         PartnerLinkInput(PartnerLinkType.HasPartner.assign, p.assign)
-      case Some(PartnerLink.HasNonPartner) =>
+      case PartnerLink.HasNonPartner         =>
         PartnerLinkInput(PartnerLinkType.HasNonPartner.assign, none.orUnassign)
-      case _                               =>
+      case PartnerLink.HasUnspecifiedPartner =>
         PartnerLinkInput(PartnerLinkType.HasUnspecifiedPartner.assign, none.orUnassign)
 
 extension (sidereal: Target.Sidereal)


### PR DESCRIPTION
For some reason we've been treating the PartnerLink as optional in the ProgramUser, when actually it is mandatory. Maybe it changed?