### PR TITLE
Don't publish to npm for snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
         run: sbt -v -J-Xmx6g tlCiRelease
 
       - name: NPM Publish
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REPO_TOKEN }}
         run: sbt -v -J-Xmx6g css/npmPublish schemasJVM/npmPublish

--- a/build.sbt
+++ b/build.sbt
@@ -277,6 +277,7 @@ ThisBuild / githubWorkflowPublish ++= Seq(
   WorkflowStep.Sbt(
     List("css/npmPublish", "schemasJVM/npmPublish"),
     name = Some("NPM Publish"),
-    env = Map("NODE_AUTH_TOKEN" -> s"$${{ secrets.NPM_REPO_TOKEN }}")
+    env = Map("NODE_AUTH_TOKEN" -> s"$${{ secrets.NPM_REPO_TOKEN }}"),
+    cond = Some("startsWith(github.ref, 'refs/tags/v')")
   )
 )


### PR DESCRIPTION
Attempting to publish snapshots to npm always fails because of an invalid tag, so why bother?